### PR TITLE
feat: add base64 image support for OpenAI-compatible VLM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,9 +219,31 @@ Max concurrency: 1
 Models: AXERA-TECH/SmolLM2-360M-Instruct
 ```
 ### 测试 OpenAI API
+
+纯文本对话：
 ```shell
 python scripts/openai_demo.py --model AXERA-TECH/SmolLM2-360M-Instruct --api_url http://127.0.0.1:8000/v1
 ```
+
+自定义 prompt：
+```shell
+python scripts/openai_demo.py --model AXERA-TECH/SmolLM2-360M-Instruct --prompt "请介绍一下你自己"
+```
+
+图文对话（VLM，图片会自动 base64 编码发送）：
+```shell
+python scripts/openai_demo.py --model AXERA-TECH/Qwen3-VL-2B-Instruct --image /path/to/image.jpg --prompt "描述一下这张图片"
+```
+
+> **参数说明**
+> | 参数 | 说明 | 默认值 |
+> |------|------|--------|
+> | `--model` | 模型名称（必填） | — |
+> | `--api_url` | API 地址 | `http://127.0.0.1:8000/v1` |
+> | `--prompt` | 用户 prompt 文本 | `hello` |
+> | `--image` | 图片路径（可选，VLM 模式） | — |
+>
+> 当指定 `--image` 时，脚本会将图片读取并以 `data:image/...;base64,...` 格式嵌入请求，服务端会自动解码为临时文件供视觉编码器使用。
 
 ## 技术讨论
 

--- a/scripts/openai_demo.py
+++ b/scripts/openai_demo.py
@@ -5,17 +5,51 @@ import requests
 import json
 import re
 import argparse
+import base64
+import os
 
 if __name__ == '__main__':
     
     parser = argparse.ArgumentParser(description='OpenAI Demo')
     parser.add_argument('--model', type=str, help='Model name')
     parser.add_argument('--api_url', type=str, help='API URL', default="http://127.0.0.1:8000/v1")
+    parser.add_argument('--image', type=str, default=None,
+                        help='Optional image path for VLM. The image will be base64-encoded and sent as image_url.')
+    parser.add_argument('--prompt', type=str, default="hello",
+                        help='User prompt text (default: "hello")')
     args = parser.parse_args()
 
     # Base URL of your API server; adjust host and port as needed
     API_URL = args.api_url
     MODEL = args.model
+
+    # Build user content
+    if args.image:
+        # VLM mode: send image + text
+        image_path = args.image
+        if not os.path.isfile(image_path):
+            print(f"Error: image file not found: {image_path}")
+            exit(1)
+
+        # Detect MIME type from extension
+        ext = os.path.splitext(image_path)[1].lower().lstrip('.')
+        mime_map = {
+            'jpg': 'jpeg', 'jpeg': 'jpeg', 'png': 'png',
+            'gif': 'gif', 'bmp': 'bmp', 'webp': 'webp', 'tiff': 'tiff',
+        }
+        mime_ext = mime_map.get(ext, 'jpeg')
+
+        with open(image_path, 'rb') as f:
+            b64_data = base64.b64encode(f.read()).decode('utf-8')
+
+        data_uri = f"data:image/{mime_ext};base64,{b64_data}"
+
+        user_content = [
+            {"type": "image_url", "image_url": {"url": data_uri}},
+            {"type": "text", "text": args.prompt},
+        ]
+    else:
+        user_content = args.prompt
 
     messages = [
         {
@@ -24,7 +58,7 @@ if __name__ == '__main__':
         },
         {
             "role": "user",
-            "content": "hello"
+            "content": user_content
         }
     ]
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <termios.h>
 #include <unistd.h>
+#include <cstdlib>
 
 #include "runner/LLM.hpp"
 #include "openai_api/server.hpp"
@@ -518,8 +519,108 @@ int run_interactive_mode(ModelConfig &config)
     return 0;
 }
 
+// ============ Base64 data-URI support ============
+static const std::string g_base64_chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz"
+    "0123456789+/";
+
+static std::vector<uint8_t> base64_decode_bytes(const std::string &encoded)
+{
+    std::vector<uint8_t> out;
+    out.reserve(encoded.size() * 3 / 4);
+    int val = 0, valb = -8;
+    for (unsigned char c : encoded)
+    {
+        if (c == '=') break;
+        auto pos = g_base64_chars.find(c);
+        if (pos == std::string::npos) continue; // skip whitespace / invalid
+        val = (val << 6) + (int)pos;
+        valb += 6;
+        if (valb >= 0)
+        {
+            out.push_back((uint8_t)((val >> valb) & 0xFF));
+            valb -= 8;
+        }
+    }
+    return out;
+}
+
+// Detect "data:image/<ext>;base64,<payload>" and return the extension + payload.
+// Uses simple string operations instead of regex to avoid stack overflow on large payloads.
+static bool parse_base64_data_uri(const std::string &uri, std::string &ext, std::string &payload)
+{
+    const std::string prefix = "data:image/";
+    if (uri.compare(0, prefix.size(), prefix) != 0) return false;
+
+    auto semi = uri.find(';', prefix.size());
+    if (semi == std::string::npos) return false;
+
+    ext = uri.substr(prefix.size(), semi - prefix.size());
+    if (ext.empty()) return false;
+
+    const std::string b64tag = "base64,";
+    if (uri.compare(semi + 1, b64tag.size(), b64tag) != 0) return false;
+
+    size_t data_start = semi + 1 + b64tag.size();
+    if (data_start >= uri.size()) return false;
+
+    payload = uri.substr(data_start);
+    return true;
+}
+
+// Decode a base64 data-URI to a temporary file and return the path.
+// Caller should eventually delete the file (or leave it in /tmp for OS cleanup).
+static std::string save_base64_to_tempfile(const std::string &ext, const std::string &payload)
+{
+    auto bytes = base64_decode_bytes(payload);
+    if (bytes.empty()) return {};
+
+    std::string tmpdir = "/tmp/axllm_images";
+    std::filesystem::create_directories(tmpdir);
+
+    // Generate a unique filename
+    auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+    std::string path = tmpdir + "/img_" + std::to_string(now) + "." + ext;
+
+    std::ofstream ofs(path, std::ios::binary);
+    if (!ofs) return {};
+    ofs.write(reinterpret_cast<const char *>(bytes.data()), bytes.size());
+    ofs.close();
+    return path;
+}
+
+// Resolve an image URI: if it's a base64 data-URI, decode to a temp file.
+// Otherwise return as-is (file path / directory).
+static std::string resolve_image_uri(const std::string &uri, std::vector<std::string> &temp_files)
+{
+    std::string ext, payload;
+    if (parse_base64_data_uri(uri, ext, payload))
+    {
+        std::string path = save_base64_to_tempfile(ext, payload);
+        if (!path.empty())
+        {
+            temp_files.push_back(path);
+        }
+        return path;
+    }
+    return uri; // plain file path
+}
+
+// Clean up temporary files created from base64 decoding.
+static void cleanup_temp_files(std::vector<std::string> &files)
+{
+    for (auto &f : files)
+    {
+        std::filesystem::remove(f);
+    }
+    files.clear();
+}
+
 // Handle HTTP API messages
-bool handle_api_messages(const nlohmann::json &messages, std::vector<Content> &history, std::vector<MediaInputs> *media_inputs = nullptr)
+bool handle_api_messages(const nlohmann::json &messages, std::vector<Content> &history,
+                         std::vector<MediaInputs> *media_inputs = nullptr,
+                         std::vector<std::string> *temp_files = nullptr)
 {
     for (auto &item : messages)
     {
@@ -561,13 +662,28 @@ bool handle_api_messages(const nlohmann::json &messages, std::vector<Content> &h
                 else if (c.contains("type") && c["type"] == "image_url")
                 {
                     // OpenAI style: {type:"image_url", image_url:{url:"..."}}
+                    // Supports file paths and data:image/...;base64,... URIs
+                    std::string raw_url;
                     if (c.contains("image_url") && c["image_url"].is_object() && c["image_url"].contains("url"))
                     {
-                        image_uris.push_back(c["image_url"]["url"].get<std::string>());
+                        raw_url = c["image_url"]["url"].get<std::string>();
                     }
                     else if (c.contains("image_url") && c["image_url"].is_string())
                     {
-                        image_uris.push_back(c["image_url"].get<std::string>());
+                        raw_url = c["image_url"].get<std::string>();
+                    }
+                    if (!raw_url.empty())
+                    {
+                        if (temp_files)
+                        {
+                            image_uris.push_back(resolve_image_uri(raw_url, *temp_files));
+                        }
+                        else
+                        {
+                            // No temp_files tracking — still try to resolve, but won't auto-cleanup
+                            std::vector<std::string> dummy;
+                            image_uris.push_back(resolve_image_uri(raw_url, dummy));
+                        }
                     }
                 }
             }
@@ -661,8 +777,10 @@ int run_server_mode(const ModelConfig &config, int port)
 
         std::vector<Content> history;
         std::vector<MediaInputs> media_inputs;
-        if (!handle_api_messages(req.messages, history, &media_inputs)) {
+        std::vector<std::string> temp_files;
+        if (!handle_api_messages(req.messages, history, &media_inputs, &temp_files)) {
             ALOGE("handle_body failed");
+            cleanup_temp_files(temp_files);
             provider->end();
             return;
         }
@@ -695,6 +813,7 @@ int run_server_mode(const ModelConfig &config, int port)
             provider->push(chunk);
         }
 
+        cleanup_temp_files(temp_files);
         provider->end(); });
 
     printf("Starting server on port %d with model '%s'...\n", port, model_name.c_str());


### PR DESCRIPTION
## Summary

Add base64 data-URI image support for the OpenAI-compatible chat completions API, enabling VLM (Vision Language Model) image input via `data:image/...;base64,...` format — the standard OpenAI API image input method.

## Changes

### C++ Server (`src/main.cpp`)
- **Base64 data-URI parsing**: Detect `data:image/<ext>;base64,<payload>` URIs in `image_url` content parts
- **Auto-decode to temp files**: Decode base64 image data and save to `/tmp/axllm_images/` for the vision encoder to process
- **Temp file cleanup**: Automatically delete temp files after each request completes
- Uses simple string operations (not regex) to avoid stack overflow on large base64 payloads

### Python Demo (`scripts/openai_demo.py`)
- Add `--image` argument: specify a local image path for VLM mode (auto base64-encoded)
- Add `--prompt` argument: custom user prompt text (default: "hello")
- Image MIME type auto-detected from file extension

### Documentation (`README.md`)
- Expanded "测试 OpenAI API" section with usage examples for text-only and VLM modes
- Added parameter reference table

## Testing

Tested on Raspberry Pi 5 with AX PCIe (AXCL backend), model: Qwen3-VL-2B-Instruct-GPTQ-Int4

- ✅ Text-only chat: `python3 openai_demo.py --model AXERA-TECH/Qwen3-VL-2B-Instruct --prompt "hello"`
- ✅ VLM with base64 image: `python3 openai_demo.py --model AXERA-TECH/Qwen3-VL-2B-Instruct --image image.png --prompt "describe the image"`
- ✅ Temp file cleanup verified (empty `/tmp/axllm_images/` after request)
- ✅ File path images still work as before (backward compatible)
