### PR TITLE
feat(serve): add port check

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -872,6 +872,14 @@ int run_server_mode(const ModelConfig &config, int port)
 {
     g_exit_on_sigint.store(true, std::memory_order_relaxed);
 
+    // Check whether port is available.
+    const char *port_error = "unknown";
+    if (!axllm::is_port_available(port, &port_error))
+    {
+        ALOGE("Port %d is unavailable: %s", port, port_error);
+        return -1;
+    }
+
     LLM llm;
 
     // Initialize engine

--- a/src/runner/utils/net_utils.cpp
+++ b/src/runner/utils/net_utils.cpp
@@ -1,6 +1,8 @@
 #include "net_utils.hpp"
 
 #include <unordered_set>
+#include <cstdint>
+#include <cerrno>
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -115,6 +117,26 @@ bool is_port_available(int port, const char **error)
         return false;
     }
 
+#ifdef _WIN32
+    WSADATA wsa_data;
+    int wsa_ret = WSAStartup(MAKEWORD(2, 2), &wsa_data);
+    if (wsa_ret != 0)
+    {
+        *error = "WSAStartup failed";
+        return false;
+    }
+
+    SOCKET sock = socket(AF_INET, SOCK_STREAM, 0);
+    if (sock == INVALID_SOCKET)
+    {
+        *error = "socket failed";
+        WSACleanup();
+        return false;
+    }
+
+    BOOL opt = TRUE;
+    setsockopt(sock, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (const char *)&opt, sizeof(opt));
+#else
     int sock = ::socket(AF_INET, SOCK_STREAM, 0);
     if (sock < 0)
     {
@@ -124,20 +146,23 @@ bool is_port_available(int port, const char **error)
 
     int opt = 1;
     setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
+#endif
     sockaddr_in addr{};
     addr.sin_family = AF_INET;
     addr.sin_addr.s_addr = htonl(INADDR_ANY);
     addr.sin_port = htons((uint16_t)port);
 
-    if (::bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    bool is_available = true;
+    if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
     {
-        int err = errno;
-        if (err == EADDRINUSE)
+        is_available = false;
+#ifdef _WIN32
+        int err = WSAGetLastError();
+        if (err == WSAEADDRINUSE)
         {
             *error = "port is already in use";
         }
-        else if (err == EACCES)
+        else if (err == WSAEACCES)
         {
             *error = "permission denied";
         }
@@ -145,12 +170,29 @@ bool is_port_available(int port, const char **error)
         {
             *error = "bind failed";
         }
-        close(sock);
-        return false;
+#else
+        if (errno == EADDRINUSE)
+        {
+            *error = "port is already in use";
+        }
+        else if (errno == EACCES)
+        {
+            *error = "permission denied";
+        }
+        else
+        {
+            *error = "bind failed";
+        }
+#endif
     }
 
+#ifdef _WIN32
+    closesocket(sock);
+    WSACleanup();
+#else
     close(sock);
-    return true;
+#endif
+    return is_available;
 }
 
 } // namespace axllm

--- a/src/runner/utils/net_utils.cpp
+++ b/src/runner/utils/net_utils.cpp
@@ -11,6 +11,8 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #endif
 
 namespace axllm {
@@ -105,5 +107,50 @@ std::vector<std::string> get_local_ipv4_addresses()
     return ips;
 }
 
-} // namespace axllm
+bool is_port_available(int port, const char **error)
+{
+    if (port <= 0 || port > 65535)
+    {
+        *error = "invalid port (must be 1-65535)";
+        return false;
+    }
 
+    int sock = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (sock < 0)
+    {
+        *error = "socket failed";
+        return false;
+    }
+
+    int opt = 1;
+    setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons((uint16_t)port);
+
+    if (::bind(sock, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) < 0)
+    {
+        int err = errno;
+        if (err == EADDRINUSE)
+        {
+            *error = "port is already in use";
+        }
+        else if (err == EACCES)
+        {
+            *error = "permission denied";
+        }
+        else
+        {
+            *error = "bind failed";
+        }
+        close(sock);
+        return false;
+    }
+
+    close(sock);
+    return true;
+}
+
+} // namespace axllm

--- a/src/runner/utils/net_utils.hpp
+++ b/src/runner/utils/net_utils.hpp
@@ -9,5 +9,7 @@ namespace axllm {
 // Useful for printing accessible server URLs when binding to 0.0.0.0.
 std::vector<std::string> get_local_ipv4_addresses();
 
-} // namespace axllm
+// Returns true if a TCP port is available.
+bool is_port_available(int port, const char **error);
 
+} // namespace axllm


### PR DESCRIPTION
Currently, `axllm serve xxx --port xx` will exit with no warning or error if the port user specified is unavailable.
This patch introduced a new function to check whether a port is available. If not, an error will be shown to the console.

It is tested under AX650 and works fine.