### PR TITLE
feat(mem-guard): pre-load CMM/DDR budget check to avoid driver crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ axllm
 
 如需 API/Gradio 示例，可继续使用 `scripts/` 下的脚本（与分支功能一致）。
 
+## 配置文件
+
+模型目录 `config.json` 的**全部字段说明**见 **[docs/configuration.md](docs/configuration.md)**（必填项、动态加载、多槽 KV 缓存、内存安全预检、VLM/视觉、Embedding、服务、AXCL 多卡等）。
+
+> 默认开启**内存安全预检**(`mem_guard_enable`)：加载模型前按文件大小估算占用并对照剩余 CMM/DDR，放不下会告警/中止（可弹 Y/N 确认），避免强行加载超额模型导致驱动崩溃。详见配置文档。
+
 ### Docker（CI 导出镜像）
 
 本仓库提供 GitHub Actions 工作流 `Docker Images` 用于构建并导出 Docker 镜像（按后端/架构拆分），产物同时提供：
@@ -201,58 +207,11 @@ VLM 模型的 `config.json` 需包含（或等价字段）：
 
 ### 动态加载（降低 CMM 占用）
 
-在 **CMM 较小** 的设备上，可开启“动态加载”以降低模型常驻 CMM 的占用：运行时仅保持少量 layer 的句柄/权重常驻，其他 layer 按需加载并在池满时释放。
-
-在模型目录 `config.json` 中配置：
-
-```json
-{
-  "dynamic_load_enable": true,
-  "dynamic_load_pool_size": 2
-}
-```
-
-- `dynamic_load_enable`：是否开启动态加载（默认 `false`）。
-- `dynamic_load_pool_size`：动态加载池大小（默认 `2`，仅在 enable 时生效）。
-
-注意：
-
-- 动态加载的目标是 **省 CMM**，通常会显著降低 token/s（尤其在 `pool_size` 远小于 layer 数量时）。
-- 当 `pool_size` 接近模型 layer 数量时，可恢复接近常规模式的性能，但此时 CMM 节省效果会变弱。
-- 当前 AXCL 后端开启动态加载时仅支持 **单卡**（多卡场景会拒绝开启）。
-- `vision_patch_size`
-
-可选字段（建议保留，未配置时会自动从视觉编码模型输入形状推断）：
-
-- `vision_width`
-- `vision_height`
-- `full_attention_interval`（Qwen3.5 等混合 linear/full attention 模型需要，用于标记每 N 层为 full-attention）
+CMM 较小的设备上可开启动态加载：运行时仅常驻少量 layer 的权重，其他按需加载、池满释放，显著省 CMM（但会降速）。配置 `dynamic_load_enable` / `dynamic_load_pool_size`，详见 [配置文档](docs/configuration.md)。
 
 ### 多槽前缀 KV 缓存（serve 多用户 / 多套提示词加速）
 
-`serve` 为单实例串行处理，但常会有**多个用户**或**多套系统提示词**轮流请求。默认只有一份上下文，一旦请求前缀和上一次不同就会重新跑整段 prefill，非常慢。开启多槽前缀 KV 缓存后，可缓存**多份**前缀 token 及其 KV：每个请求按**最长公共前缀**匹配到对应的槽并复用其 KV（只对新增 token 做 prefill），未命中则覆盖**最久未使用**（LRU）的槽。一次仍只处理一个请求。
-
-在模型目录 `config.json` 中配置：
-
-```json
-{
-  "kv_cache_slots": 4,
-  "kv_cache_slot_location": "device"
-}
-```
-
-- `kv_cache_slots`：缓存槽数量（默认 `1`，即关闭多槽、与原行为完全一致）。
-- `kv_cache_slot_location`：KV 存放位置（默认 `device`）。
-  - `device`：每槽一份设备 KV buffer，激活时**零拷贝重绑定**，切换最快；代价是 N× 设备 CMM。
-  - `host`（或 `ddr`）：单份设备 KV + 每槽一份主机内存副本，激活时 D2H/H2D 拷贝；**省 CMM**（无论多少槽只占一份设备 buffer），切换有拷贝开销。
-
-说明：
-
-- 文本 LLM 与 **VLM 均支持**；VLM 命中复用时会**跳过 vision encoder 重跑**。
-- **自动预算**：开启时会先评估一份槽的占用，并按剩余 CMM / 主机内存（保留安全余量）决定实际能开几份。若实际能开的份数 **< 配置值**，会告警并按能开的份数启用（而非 OOM 崩溃）。例如配置 4 份但显存只够 3 份，就用 3 份并打印 `⚠` 告警。
-- 与 `dynamic_load_enable` 暂不可同时开启（同时配置会告警并退回单槽）。
-
-更多细节见 [docs/multi_slot_kv_cache.md](docs/multi_slot_kv_cache.md)。
+`serve` 单实例串行处理，多个用户 / 多套系统提示词轮流请求时，默认只有一份上下文会反复重跑 prefill。开启多槽后可缓存多份前缀 KV，按最长公共前缀命中复用、未命中覆盖 LRU（文本与 VLM 均支持，VLM 复用时跳过 vision encoder）。配置 `kv_cache_slots` / `kv_cache_slot_location`，详见 [配置文档](docs/configuration.md) 与 [设计文档](docs/multi_slot_kv_cache.md)。
 
 ### Embedding（/v1/embeddings）使用说明
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,7 @@
 |---|---|---|
 | `model_name` | string | 模型名(显示在 `/v1/models`、日志) |
 | `tokenizer_type` | string | 分词器类型(如 `Qwen3` / `Qwen3VL` / `Gemma4VL` / `SmolLM2` …) |
-| `url_tokenizer_model` | string | 分词器文件路径或 HTTP 地址 |
+| `url_tokenizer_model` | string | **本地**分词器文件路径(如 `qwen3_tokenizer.txt`)。⚠ 字段名带 `url`、默认值带 `http` 都是历史遗留;**当前只读本地文件,不支持 HTTP** |
 | `template_filename_axmodel` | string | 每层 axmodel 文件名模板,含 `%d`(如 `qwen3_p128_l%d_together.axmodel`) |
 | `axmodel_num` | int | transformer 层数 |
 | `filename_post_axmodel` | string | 输出 logits 的 post axmodel |
@@ -26,7 +26,7 @@
 | `post_config_path` | `post_config.json` | 采样配置文件 |
 | `bos` / `eos` | `true` / `false` | 是否加 BOS/EOS |
 | `pad_token_id` | 0 | pad token id |
-| `thinking_mode` / `enable_thinking` | 模型默认 | 推理(思考)模式开关,用于 Qwen3 / MiniCPM5 等带思考链的模型;也可在 `/v1/chat/completions` 请求里按次覆盖 |
+| `enable_thinking`(bool) 或 `thinking_mode`(string) | 模型默认 | 思考链开关(Qwen3 / MiniCPM5 等)。`enable_thinking`: `true`/`false`;`thinking_mode`: `think`/`no_think`/`default`(`default`/`auto`=按模型默认)。也可在 `/v1/chat/completions` 请求里按次覆盖 |
 
 ## 加载与内存
 
@@ -59,6 +59,8 @@
 | `sliding_window` | 0 | 滑动窗口大小 |
 | `num_kv_shared_layers` | 0 | 末尾共享 KV 的层数 |
 
+> 这几项也可不在 `config.json` 顶层写:`full_attention_interval` / `num_kv_shared_layers` 会回退读 `text_config.*`;`sliding_window` / `layer_types` 未配置时会自动从模型目录下分词器的 sidecar config 读取。
+
 ## 多槽前缀 KV 缓存（serve 多用户/多提示词加速）
 
 | 字段 | 默认 | 说明 |
@@ -80,13 +82,12 @@
 | `vision_patch_size` / `vision_temporal_patch_size` / `vision_spatial_merge_size` | 14 / 2 / 2 | patchify 参数 |
 | `vision_fps` / `vision_tokens_per_second` | 1 / 1 | 视频时间缩放(Qwen2.5-VL mRoPE) |
 | `vision_num_frames` / `vision_do_sample_frames` | 0 / true | 视频抽帧上限 / 是否均匀抽帧 |
-| `video_processor` | — | 视频处理器选择(部分模型) |
 
 ## Embedding
 
 | 字段 | 默认 | 说明 |
 |---|---|---|
-| `is_embedding`(别名 `embedding`/`embedding_type`) | `false` | 以 Embedding 模式启动,提供 `/v1/embeddings`(不支持 `run`) |
+| `is_embedding`(别名 `embedding`;旧 `embedding_type`/`EMBEDDING_TYPE` 已废弃) | `false` | 以 Embedding 模式启动,提供 `/v1/embeddings`(不支持 `run`) |
 
 ## Gemma4 per-layer 投影
 
@@ -102,8 +103,8 @@
 |---|---|---|
 | `port` | 8000 | 监听端口 |
 | `server_timeout_ms` | 300000 | 请求超时(并发排队也复用该值) |
-| `server_default_max_tokens` | — | 请求默认 max_tokens |
-| `server_max_output_tokens` | — | 输出 token 硬上限 |
+| `server_default_max_tokens` | 0 | 请求未带 max_tokens 时的默认值(0=用内置默认) |
+| `server_max_output_tokens` | 0 | 输出 token 硬上限(0=不额外限制) |
 | `server_forced_prompt_text` | — | 强制提示词(如 OCR 规整) |
 
 ## AXCL（PCIe 多卡）

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,120 @@
+# 配置文件说明（模型目录 `config.json`）
+
+`axllm` 启动时读取 `<model_dir>/config.json`。下面按用途分组列出所有可用字段;**未列为必填的都是可选**,不填用默认值。
+
+> 路径类字段(`filename_*` / `template_filename_axmodel` / `post_config_path` 等)相对模型目录解析。
+
+## 必填
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| `model_name` | string | 模型名(显示在 `/v1/models`、日志) |
+| `tokenizer_type` | string | 分词器类型(如 `Qwen3` / `Qwen3VL` / `Gemma4VL` / `SmolLM2` …) |
+| `url_tokenizer_model` | string | 分词器文件路径或 HTTP 地址 |
+| `template_filename_axmodel` | string | 每层 axmodel 文件名模板,含 `%d`(如 `qwen3_p128_l%d_together.axmodel`) |
+| `axmodel_num` | int | transformer 层数 |
+| `filename_post_axmodel` | string | 输出 logits 的 post axmodel |
+| `filename_tokens_embed` | string | token embedding 权重(bf16 bin) |
+| `tokens_embed_num` | int | 词表大小 |
+| `tokens_embed_size` | int | embedding 维度 |
+
+## 通用 / 分词
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `system_prompt` | 空 | 缺省系统提示词,缺失时自动前置 |
+| `post_config_path` | `post_config.json` | 采样配置文件 |
+| `bos` / `eos` | `true` / `false` | 是否加 BOS/EOS |
+| `pad_token_id` | 0 | pad token id |
+| `thinking_mode` / `enable_thinking` | 模型默认 | 推理(思考)模式开关,用于 Qwen3 / MiniCPM5 等带思考链的模型;也可在 `/v1/chat/completions` 请求里按次覆盖 |
+
+## 加载与内存
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `use_mmap_load_embed`(别名 `b_use_mmap_load_embed`) | `false` | embedding 用 mmap 加载(省内存) |
+| `use_mmap_load_layer`(别名 `b_use_mmap_load_layer`) | `true`(仅 AX650) | 层权重用 mmap |
+| `dynamic_load_enable` | `false` | 动态加载层(省 CMM,降速),见 README |
+| `dynamic_load_pool_size` | `2` | 动态加载常驻层数(仅 enable 时) |
+| **`mem_guard_enable`** | `true` | **加载前内存预检总开关**(见下「内存安全预检」) |
+| **`mem_guard_floor_mb`** | `128` | 估算占用之上额外保留的安全余量(MB) |
+| **`mem_guard_on_unsafe`** | `prompt` | 不安全时:`prompt`(有TTY弹Y/N,无TTY=abort)/ `abort` / `warn` |
+
+### 内存安全预检（防止超 CMM/DDR 加载导致驱动崩溃）
+
+开启后,加载模型前会按**文件大小**估算各部分占用,并对照剩余内存判断是否安全:
+
+- **CMM**(设备显存,各层 / post / 视觉&音频编码器):用现有 `remain` 查询(AX650 读 `/proc/ax_proc/mem_cmm_info`,AXCL 经 axcl-smi),多卡按各卡分别核算。
+- **DDR**(主机内存,token embedding 非 mmap 时 / Gemma per-layer 权重):读 `/proc/meminfo` 的 **MemAvailable**(已扣可回收 buffer/cache,是"真正可用",避免误报)。
+- 若 `剩余 - 估算 < mem_guard_floor_mb` → 按 `mem_guard_on_unsafe` 处理:`abort` 直接中止并报错;`warn` 仅告警继续;`prompt` 在交互式终端弹 `[y/N]`(默认 N=不加载),无终端(serve/docker)时退化为 `abort`。
+- 关闭:`mem_guard_enable=false`。
+- 说明:`dynamic_load_enable=true` 时层权重会在加载后释放,故预检不计层权重(只算 post/编码器/主机部分)。
+
+## 注意力(混合注意力 / 长上下文模型)
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `full_attention_interval` | 0 | 每 N 层(1-indexed)为 full-attention,其余 linear(如 Qwen3.5) |
+| `layer_types` | 空 | 显式每层类型数组(`full_attention`/`linear_attention`/`sliding_attention`) |
+| `sliding_window` | 0 | 滑动窗口大小 |
+| `num_kv_shared_layers` | 0 | 末尾共享 KV 的层数 |
+
+## 多槽前缀 KV 缓存（serve 多用户/多提示词加速）
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `kv_cache_slots` | 1 | 槽数,1=关闭(等于现状) |
+| `kv_cache_slot_location` | `device` | `device`(零拷贝指针切换)/ `host`(省 CMM,切换拷贝) |
+
+详见 [multi_slot_kv_cache.md](multi_slot_kv_cache.md)。
+
+## VLM / 视觉 / 音频
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `vlm_type`(别名 `VLM_TYPE`) | `None` | `Qwen2_5VL`/`Qwen3VL`/`InternVL3`/`FastVLM`/`SmolVLM2`/`PaddleOCRVL`/`Gemma4VL`/`MiniCPMV46VL` |
+| `filename_image_encoder_axmodel` | — | 视觉编码器 axmodel(VLM 必填) |
+| `filename_audio_encoder_axmodel_5s` / `_30s` | — | Gemma4 音频编码器(ASR) |
+| `vision_cache_dir` | 空 | 视觉 embedding 磁盘缓存目录 |
+| `vision_width` / `vision_height` | 448 | 视觉输入尺寸(未配置时按编码器输入形状自动推断) |
+| `vision_patch_size` / `vision_temporal_patch_size` / `vision_spatial_merge_size` | 14 / 2 / 2 | patchify 参数 |
+| `vision_fps` / `vision_tokens_per_second` | 1 / 1 | 视频时间缩放(Qwen2.5-VL mRoPE) |
+| `vision_num_frames` / `vision_do_sample_frames` | 0 / true | 视频抽帧上限 / 是否均匀抽帧 |
+| `video_processor` | — | 视频处理器选择(部分模型) |
+
+## Embedding
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `is_embedding`(别名 `embedding`/`embedding_type`) | `false` | 以 Embedding 模式启动,提供 `/v1/embeddings`(不支持 `run`) |
+
+## Gemma4 per-layer 投影
+
+| 字段 | 说明 |
+|---|---|
+| `hidden_size_per_layer_input` | per-layer 投影维度(>0 时启用) |
+| `rms_norm_eps` | RMSNorm eps |
+| `filename_tokens_embed_per_layer` / `filename_per_layer_model_projection` / `filename_per_layer_projection_norm` | per-layer 权重文件 |
+
+## 服务（serve）
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `port` | 8000 | 监听端口 |
+| `server_timeout_ms` | 300000 | 请求超时(并发排队也复用该值) |
+| `server_default_max_tokens` | — | 请求默认 max_tokens |
+| `server_max_output_tokens` | — | 输出 token 硬上限 |
+| `server_forced_prompt_text` | — | 强制提示词(如 OCR 规整) |
+
+## AXCL（PCIe 多卡）
+
+| 字段 | 默认 | 说明 |
+|---|---|---|
+| `devices` | `[0]` | 使用的设备 id 列表(多卡张量并行) |
+
+## 图像生成（SD1.5）
+
+| 字段 | 说明 |
+|---|---|
+| `model_type` / `task_type` = `image_generation` 或 `is_image_generation=true` | 以图像生成模式启动,提供 `/v1/images/*` |
+| `image_model_dir` | 图像模型根目录 |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,6 +443,18 @@ struct ModelConfig
                 attr.kv_cache_slot_location = j["kv_cache_slot_location"].get<std::string>();
             }
 
+            // Pre-load memory guard.
+            json_bool_value(j, "mem_guard_enable", attr.mem_guard_enable);
+            if (auto v = json_int_value(j, "mem_guard_floor_mb"); v.has_value())
+            {
+                attr.mem_guard_floor_mb = *v;
+            }
+            if (attr.mem_guard_floor_mb < 0) attr.mem_guard_floor_mb = 0;
+            if (j.contains("mem_guard_on_unsafe") && j["mem_guard_on_unsafe"].is_string())
+            {
+                attr.mem_guard_on_unsafe = j["mem_guard_on_unsafe"].get<std::string>();
+            }
+
             // Optional: models with mixed linear/full attention layers (e.g., Qwen3.5).
             // Keep config minimal: only an interval is needed (layer count comes from `axmodel_num`).
             attr.full_attention_interval = 0;

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -30,6 +30,8 @@
 
 #include "vision/vision_module.hpp"
 
+#include "ax_cmm_utils.hpp"  // memory queries + pre-load mem guard (both backends)
+
 #ifdef USE_AXCL
 #include "ax_model_runner/ax_model_runner_axcl.hpp"
 #include "utils/axcl_manager.h"
@@ -2429,6 +2431,103 @@ struct LLM::Impl {
         return true;
     }
 
+    // ---- Pre-load memory guard helpers ----
+    int device_remaining_cmm_mb(int devid) const
+    {
+#ifdef USE_AXCL
+        return axcl_GetCMMRemain(devid);
+#else
+        (void)devid;
+        return get_remaining_cmm_size();
+#endif
+    }
+
+    // Guard a device (CMM) load. `est_mb` defaults to the model file size.
+    bool guard_device_load(const std::string &file, int devid, int est_mb = -1)
+    {
+        if (!_attr.mem_guard_enable) return true;
+        if (est_mb < 0) est_mb = estimate_model_mb(file);
+        const int remain = device_remaining_cmm_mb(devid);
+        if (mem_guard_allow_load(_attr.mem_guard_enable, _attr.mem_guard_floor_mb,
+                                 _attr.mem_guard_on_unsafe, file, est_mb, remain))
+            return true;
+        set_last_error("CMM 不足，已中止加载: " + file + "（可调小模型/释放显存，或在 config.json 设 mem_guard_enable=false）");
+        ALOGE("mem-guard aborted device load: %s (est %d MB, remain %d MB)", file.c_str(), est_mb, remain);
+        return false;
+    }
+
+    // Guard a host (DDR) load.
+    bool guard_host_load(const std::string &file, int est_mb = -1)
+    {
+        if (!_attr.mem_guard_enable) return true;
+        if (est_mb < 0) est_mb = estimate_model_mb(file);
+        const int remain = get_remaining_ddr_size();
+        if (mem_guard_allow_load(_attr.mem_guard_enable, _attr.mem_guard_floor_mb,
+                                 _attr.mem_guard_on_unsafe, file, est_mb, remain))
+            return true;
+        set_last_error("主机内存(DDR)不足，已中止加载: " + file + "（或在 config.json 设 mem_guard_enable=false）");
+        ALOGE("mem-guard aborted host load: %s (est %d MB, remain %d MB)", file.c_str(), est_mb, remain);
+        return false;
+    }
+
+    // Pre-flight memory budget check before loading any model piece. Sums the
+    // estimated footprint (~file sizes) and checks it against remaining CMM (per
+    // device) and host DDR. `dev_of_layer` gives each layer's device id for
+    // multi-device (AXCL); empty => single on-chip device (AX650, devid -1).
+    bool mem_preflight(const std::vector<int> &dev_of_layer)
+    {
+        if (!_attr.mem_guard_enable) return true;
+
+        // Host DDR: token embedding (only when read fully into RAM, not mmap) +
+        // optional Gemma per-layer projection weights.
+        int host_mb = 0;
+        if (!_attr.b_use_mmap_load_embed)
+            host_mb += estimate_model_mb(_attr.filename_tokens_embed);
+        if (_attr.hidden_size_per_layer_input > 0)
+        {
+            host_mb += estimate_model_mb(_attr.filename_tokens_embed_per_layer);
+            host_mb += estimate_model_mb(_attr.filename_per_layer_model_projection);
+            host_mb += estimate_model_mb(_attr.filename_per_layer_projection_norm);
+        }
+        if (host_mb > 0 && !guard_host_load("host: token-embedding / per-layer weights", host_mb))
+            return false;
+
+        // CMM: vision/audio encoders (always fully resident) + post + layers.
+        int enc_mb = 0;
+        if (_attr.vlm_type != VLMType::None)
+        {
+            enc_mb += estimate_model_mb(_attr.filename_image_encoder_axmodel);
+            enc_mb += estimate_model_mb(_attr.filename_audio_encoder_axmodel_5s);
+            enc_mb += estimate_model_mb(_attr.filename_audio_encoder_axmodel_30s);
+        }
+        // Dynamic load frees layer weights after init, so don't count them; their
+        // residency is bounded by the pool, and dynamic load is the save-CMM mode.
+        const bool count_layers = !dynamic_layer_load_enabled();
+
+        if (dev_of_layer.empty())
+        {
+            int cmm_mb = enc_mb + estimate_model_mb(_attr.filename_post_axmodel);
+            if (count_layers)
+                for (auto &l : llama_layers) cmm_mb += estimate_model_mb(l.filename);
+            if (!guard_device_load("device CMM (encoders + post" + std::string(count_layers ? " + all layers)" : ")"), -1, cmm_mb))
+                return false;
+        }
+        else
+        {
+            std::map<int, int> need;
+            if (count_layers)
+                for (size_t i = 0; i < llama_layers.size() && i < dev_of_layer.size(); ++i)
+                    need[dev_of_layer[i]] += estimate_model_mb(llama_layers[i].filename);
+            const int post_dev = dev_of_layer.back();
+            need[post_dev] += estimate_model_mb(_attr.filename_post_axmodel);
+            need[dev_of_layer.front()] += enc_mb;
+            for (const auto &kv : need)
+                if (!guard_device_load("device " + std::to_string(kv.first) + " CMM", kv.first, kv.second))
+                    return false;
+        }
+        return true;
+    }
+
     bool Init(LLMAttrType attr)
     {
         ALOGI("LLM init start");
@@ -2516,6 +2615,8 @@ struct LLM::Impl {
             if (dev_idx >= 0 && (size_t)dev_idx < _attr.dev_ids.size())
                 dynamic_layer_devids_[(size_t)i] = _attr.dev_ids[(size_t)dev_idx];
         }
+
+        if (!mem_preflight(dynamic_layer_devids_)) return false;
 
         if (dynamic_layer_load_enabled())
         {
@@ -2648,6 +2749,7 @@ struct LLM::Impl {
             sprintf(axmodel_path, attr.template_filename_axmodel.c_str(), i);
             llama_layers[i].filename = axmodel_path;
         }
+        if (!mem_preflight({})) return false;
         if (dynamic_layer_load_enabled())
         {
             for (int i = 0; i < attr.axmodel_num; i++)

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -70,6 +70,19 @@ struct LLMAttrType {
     // "host" (DDR copy on switch, reserved for a follow-up).
     std::string kv_cache_slot_location = "device";
 
+    // ---- Pre-load memory guard (avoid loading models that overflow CMM/DDR
+    //      and crash the NPU driver) ----
+    // Before loading each piece (layer / post / vision & audio encoders / token
+    // embedding / per-layer projections) the estimated footprint (~file size) is
+    // checked against the remaining CMM (device pieces) or host DDR (host pieces).
+    bool mem_guard_enable = true;     // master switch
+    int mem_guard_floor_mb = 128;     // keep at least this much free after a load
+    // What to do when a load would breach the floor:
+    //   "prompt" : ask [y/N] on a TTY, otherwise abort (serve / headless)
+    //   "abort"  : refuse the load with a clear error
+    //   "warn"   : log a warning and load anyway
+    std::string mem_guard_on_unsafe = "prompt";
+
     std::vector<int> prefill_max_kv_cache_num_grp;
     int prefill_grpid = -1;
     std::string post_config_path = "post_config.json";

--- a/src/runner/utils/ax_cmm_utils.hpp
+++ b/src/runner/utils/ax_cmm_utils.hpp
@@ -7,6 +7,11 @@
 #include <cstdlib>
 #include <string>
 #include <filesystem>
+#include <iostream>
+#include <cctype>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 // #include "sample_log.h"
 
@@ -134,6 +139,36 @@ static int get_remaining_cmm_size()
     return -1;
 }
 
+// Truly-available host DDR in MB. Uses /proc/meminfo MemAvailable, which already
+// accounts for reclaimable page cache / shared buffers, so it reflects what can
+// actually be allocated (avoids false alarms from buff/cache). Returns -1 if it
+// cannot be determined (e.g. non-Linux), so callers can skip the DDR check.
+static int get_remaining_ddr_size()
+{
+#ifdef _WIN32
+    return -1;
+#else
+    std::ifstream meminfo("/proc/meminfo");
+    if (!meminfo.is_open()) return -1;
+    std::string line;
+    long mem_available_kb = -1, mem_free_kb = -1;
+    while (std::getline(meminfo, line))
+    {
+        if (line.rfind("MemAvailable:", 0) == 0)
+        {
+            std::sscanf(line.c_str(), "MemAvailable: %ld kB", &mem_available_kb);
+            break;
+        }
+        if (line.rfind("MemFree:", 0) == 0)
+            std::sscanf(line.c_str(), "MemFree: %ld kB", &mem_free_kb);
+    }
+    // Older kernels may lack MemAvailable; fall back to MemFree.
+    long kb = mem_available_kb >= 0 ? mem_available_kb : mem_free_kb;
+    if (kb < 0) return -1;
+    return (int)(kb / 1024);
+#endif
+}
+
 static int get_pcie_remaining_cmm_size(int devid)
 {
     const std::string axcl_smi = get_axcl_smi_cmd();
@@ -155,4 +190,55 @@ static int get_pcie_remaining_cmm_size(int devid)
         return remain_mb;
     }
     return -1;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-load memory guard
+// ---------------------------------------------------------------------------
+// Estimated footprint (MB) of a model file ~= its on-disk size (weights dominate
+// device/host usage). 0 if the file can't be stat'd.
+static int estimate_model_mb(const std::string &path)
+{
+    std::error_code ec;
+    auto sz = std::filesystem::file_size(path, ec);
+    if (ec) return 0;
+    return (int)(sz / (1024 * 1024));
+}
+
+// Decide whether it is safe to load a piece of size `est_mb` given `remaining_mb`
+// of the relevant memory pool. Returns true to proceed, false to abort.
+// on_unsafe: "abort" | "warn" | "prompt" (prompt asks on a TTY, else aborts).
+static bool mem_guard_allow_load(bool enable, int floor_mb, const std::string &on_unsafe,
+                                 const std::string &what, int est_mb, int remaining_mb)
+{
+    if (!enable) return true;
+    if (remaining_mb < 0) return true; // pool unknown (e.g. non-Linux / no proc) -> don't block
+    const int after = remaining_mb - est_mb;
+    if (after >= floor_mb) return true; // safe
+
+    std::string mode = on_unsafe.empty() ? "prompt" : on_unsafe;
+    for (auto &c : mode) c = (char)std::tolower((unsigned char)c);
+
+    fprintf(stderr,
+            "[mem-guard] UNSAFE: loading '%s' (~%d MB) would leave ~%d MB free "
+            "(< floor %d MB); remaining=%d MB\n",
+            what.c_str(), est_mb, after, floor_mb, remaining_mb);
+
+    if (mode == "warn") return true;
+    if (mode == "abort") return false;
+    // prompt
+#ifndef _WIN32
+    if (isatty(STDIN_FILENO))
+    {
+        fprintf(stderr, "[mem-guard] Continue loading anyway? [y/N]: ");
+        fflush(stderr);
+        std::string line;
+        if (!std::getline(std::cin, line)) return false;
+        for (auto &c : line) c = (char)std::tolower((unsigned char)c);
+        return line == "y" || line == "yes";
+    }
+#endif
+    fprintf(stderr, "[mem-guard] non-interactive (no TTY): aborting load. "
+                    "Set mem_guard_on_unsafe=warn to force, or mem_guard_enable=false to disable.\n");
+    return false;
 }


### PR DESCRIPTION
Loading a model that overflows device CMM (or host DDR) could hard-crash the NPU driver. Now each load is checked first:

- new get_remaining_ddr_size() (host /proc/meminfo MemAvailable: accounts for reclaimable buffers => true available, avoids false alarms); CMM uses the existing per-device queries.
- pre-flight estimates each piece (~file size) and checks remaining CMM per device + host DDR before loading layers / post / vision&audio encoders / token embedding. Dynamic-load mode skips the layer-weight estimate (weights are freed after init).
- config: mem_guard_enable (default true), mem_guard_floor_mb (128), mem_guard_on_unsafe = prompt|abort|warn. prompt asks [y/N] on a TTY and aborts when headless (serve/docker), so it never hangs a server.
- docs/configuration.md: full config.json reference; README config sections trimmed to point to it.
- Verified on AXCL: model fits => loads; floor=huge + abort => refused with a clear error and no driver crash; + warn => loads with a warning.