### PR TITLE
Feat/native tool call

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ axllm
 
 模型目录 `config.json` 的**全部字段说明**见 **[docs/configuration.md](docs/configuration.md)**（必填项、动态加载、多槽 KV 缓存、内存安全预检、VLM/视觉、Embedding、服务、AXCL 多卡等）。
 
+> **工具调用（Tool / Function Calling）**：`serve` 支持 OpenAI 兼容的工具调用，**目前仅支持 Qwen3 系模型**（文本与 VLM 均可），用法见 **[docs/tool_calling.md](docs/tool_calling.md)**。
+
 > 默认开启**内存安全预检**(`mem_guard_enable`)：加载模型前按文件大小估算占用并对照剩余 CMM/DDR，放不下会告警/中止（可弹 Y/N 确认），避免强行加载超额模型导致驱动崩溃。详见配置文档。
 
 ### Docker（CI 导出镜像）

--- a/docs/tool_calling.md
+++ b/docs/tool_calling.md
@@ -6,17 +6,22 @@ result back, and the model produces a final answer.
 
 ## Supported models
 
-> **Only the Qwen3 family is supported right now.**
+> **Supported: the Qwen3 family and MiniCPM-V-4.6.**
 > Tool calling uses Qwen3's `<tool_call>{...}</tool_call>` prompt format, so it works for
 > `tokenizer_type` = `Qwen3`, `Qwen3VL`, `Qwen2_5`, `Qwen3_5`, `Qwen3_5VL`, `Qwen3Omni`
-> (i.e. any model handled by the Qwen3 tokenizer). Both text and VLM (image + tools) work.
+> (any model handled by the Qwen3 tokenizer), plus `MiniCPMV46` / `MiniCPMV46VL`
+> (MiniCPM-V-4.6, whose text backbone is Qwen3.5 and shares the same tool convention).
+> Both text and VLM (image + tools) work.
 >
-> **Other model families are not supported.** If you send `tools` to a non-Qwen3 model,
+> **Other model families are not supported.** If you send `tools` to an unsupported model,
 > the tool section is not rendered and the model will simply answer in text (no
 > `tool_calls` will be returned).
 >
 > Practical note for small models: on ≤4B models the model occasionally answers directly
-> instead of calling a tool. Use `tool_choice: "required"` to force a call.
+> instead of calling a tool. Use `tool_choice: "required"` to force a call. Tool calling is
+> also most reliable with **greedy decoding** (sampling disabled) -- under sampling a small
+> model is likelier to chatter instead of emitting a clean `<tool_call>` (e.g. MiniCPM-V-4.6
+> tests: 6/6 greedy vs 2/6 at temperature 0.7).
 
 ## Request
 
@@ -116,7 +121,7 @@ request; tool calling behaves the same as text.
 
 ## Limitations
 
-- Qwen3 `<tool_call>` format only; other model families are not supported.
+- Qwen3 `<tool_call>` format only (Qwen3 family + MiniCPM-V-4.6); other model families are not supported.
 - Streaming tool calls are buffered (not token-incremental).
 - Reliability on ≤4B models is model-dependent (~95%); use `tool_choice: "required"` when a
   tool call is mandatory.

--- a/docs/tool_calling.md
+++ b/docs/tool_calling.md
@@ -1,0 +1,122 @@
+# Tool / Function Calling (OpenAI-compatible)
+
+`serve` mode supports OpenAI-style tool (function) calling: the client sends a `tools`
+list, the model may respond with `tool_calls`, the client runs the tool and feeds the
+result back, and the model produces a final answer.
+
+## Supported models
+
+> **Only the Qwen3 family is supported right now.**
+> Tool calling uses Qwen3's `<tool_call>{...}</tool_call>` prompt format, so it works for
+> `tokenizer_type` = `Qwen3`, `Qwen3VL`, `Qwen2_5`, `Qwen3_5`, `Qwen3_5VL`, `Qwen3Omni`
+> (i.e. any model handled by the Qwen3 tokenizer). Both text and VLM (image + tools) work.
+>
+> **Other model families are not supported.** If you send `tools` to a non-Qwen3 model,
+> the tool section is not rendered and the model will simply answer in text (no
+> `tool_calls` will be returned).
+>
+> Practical note for small models: on ≤4B models the model occasionally answers directly
+> instead of calling a tool. Use `tool_choice: "required"` to force a call.
+
+## Request
+
+Add `tools` (and optionally `tool_choice`) to a `/v1/chat/completions` request:
+
+```json
+{
+  "model": "AXERA-TECH/Qwen3-1.7B",
+  "messages": [{"role": "user", "content": "What's the weather in Beijing?"}],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get the current weather for a city",
+        "parameters": {
+          "type": "object",
+          "properties": {"city": {"type": "string"}},
+          "required": ["city"]
+        }
+      }
+    }
+  ]
+}
+```
+
+`tool_choice` (default `auto`):
+
+| value | behavior |
+|-------|----------|
+| `"auto"` | model decides whether to call a tool (default) |
+| `"none"` | tools are not offered; model answers in text |
+| `"required"` | model is instructed to call one of the tools |
+| `{"type":"function","function":{"name":"X"}}` | model is instructed to call function `X` |
+
+`tool_choice` is a prompt-level instruction, so on small models it is a strong hint, not a
+hard guarantee (a model may still refuse to call a clearly-inappropriate forced tool).
+
+## Response
+
+When the model calls a tool, the response has `finish_reason: "tool_calls"` and a
+`message.tool_calls` array (`content` is null):
+
+```json
+{
+  "choices": [{
+    "finish_reason": "tool_calls",
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [{
+        "id": "call_0_get_weather",
+        "type": "function",
+        "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}
+      }]
+    }
+  }]
+}
+```
+
+`function.arguments` is a JSON **string** (OpenAI convention).
+
+## Feeding the tool result back (multi-turn)
+
+Run the tool, then send the conversation back including the assistant's `tool_calls` and a
+`role: "tool"` message with the result:
+
+```json
+{
+  "model": "AXERA-TECH/Qwen3-1.7B",
+  "messages": [
+    {"role": "user", "content": "What's the weather in Beijing?"},
+    {"role": "assistant", "content": null, "tool_calls": [
+      {"id": "call_0_get_weather", "type": "function",
+       "function": {"name": "get_weather", "arguments": "{\"city\":\"Beijing\"}"}}]},
+    {"role": "tool", "tool_call_id": "call_0_get_weather",
+     "content": "{\"temperature\":\"32C\",\"condition\":\"sunny\"}"}
+  ],
+  "tools": [ ... same tools ... ]
+}
+```
+
+The model then returns a normal text answer (`finish_reason: "stop"`), e.g.
+*"The current weather in Beijing is 32°C and sunny."*
+
+## Streaming
+
+With `"stream": true`, when tools are active the tool call is emitted as a single
+`delta.tool_calls` chunk followed by a finish chunk with `finish_reason: "tool_calls"`.
+When the model answers in text instead, normal text deltas are streamed. (Streaming with
+tools is buffered internally rather than token-incremental for the tool-call arguments.)
+
+## Vision + tools
+
+VLM models (e.g. `Qwen3-VL-2B-Instruct`) can be given an image and tools in the same
+request; tool calling behaves the same as text.
+
+## Limitations
+
+- Qwen3 `<tool_call>` format only; other model families are not supported.
+- Streaming tool calls are buffered (not token-incremental).
+- Reliability on ≤4B models is model-dependent (~95%); use `tool_choice: "required"` when a
+  tool call is mandatory.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2988,11 +2988,13 @@ int main(int argc, char *argv[])
             std::string arg = argv[i];
             if (arg == "--port" && i + 1 < argc)
             {
-                port = std::stoi(argv[++i]);
+                try { port = std::stoi(argv[++i]); }
+                catch (const std::exception &) { ALOGW("invalid --port value '%s', ignoring", argv[i]); }
             }
             else if (arg == "--server_timeout_ms" && i + 1 < argc)
             {
-                config.server_timeout_ms = std::stoi(argv[++i]);
+                try { config.server_timeout_ms = std::stoi(argv[++i]); }
+                catch (const std::exception &) { ALOGW("invalid --server_timeout_ms value '%s', ignoring", argv[i]); }
             }
             else if (arg == "--help" || arg == "-h")
             {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1960,6 +1960,59 @@ static void infer_media_type_from_uri_prefix(std::string &raw_url, ContentType &
 }
 
 // Handle HTTP API messages
+// ---------------- Native tool calling (Qwen3 <tool_call> format) ----------------
+// Render an OpenAI "tools" array into the Qwen3 system-prompt tool section.
+static std::string render_qwen3_tools_section(const nlohmann::json &tools)
+{
+    if (!tools.is_array() || tools.empty()) return {};
+    std::string s;
+    s += "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\n";
+    s += "You are provided with function signatures within <tools></tools> XML tags:\n<tools>";
+    for (const auto &t : tools) s += "\n" + t.dump();
+    s += "\n</tools>\n\n";
+    s += "For each function call, return a json object with function name and arguments within "
+         "<tool_call></tool_call> XML tags:\n<tool_call>\n"
+         "{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>";
+    return s;
+}
+
+// Extract <tool_call>{...}</tool_call> blocks from model output -> OpenAI tool_calls array.
+static nlohmann::json parse_tool_calls_from_text(const std::string &text)
+{
+    nlohmann::json calls = nlohmann::json::array();
+    const std::string open = "<tool_call>", close = "</tool_call>";
+    size_t pos = 0; int idx = 0;
+    while (true)
+    {
+        size_t a = text.find(open, pos);
+        if (a == std::string::npos) break;
+        size_t b = text.find(close, a + open.size());
+        if (b == std::string::npos) break;
+        std::string body = text.substr(a + open.size(), b - (a + open.size()));
+        pos = b + close.size();
+        size_t s0 = body.find_first_not_of(" \t\r\n");
+        size_t s1 = body.find_last_not_of(" \t\r\n");
+        if (s0 == std::string::npos) continue;
+        body = body.substr(s0, s1 - s0 + 1);
+        nlohmann::json obj;
+        try { obj = nlohmann::json::parse(body); } catch (...) { continue; }
+        std::string name = obj.value("name", std::string());
+        if (name.empty() && obj.contains("function") && obj["function"].is_object())
+            name = obj["function"].value("name", std::string());
+        if (name.empty()) continue;
+        nlohmann::json args = obj.contains("arguments") ? obj["arguments"]
+                              : (obj.contains("parameters") ? obj["parameters"] : nlohmann::json::object());
+        nlohmann::json call;
+        call["id"] = std::string("call_") + std::to_string(idx) + "_" + name;
+        call["type"] = "function";
+        call["function"]["name"] = name;
+        call["function"]["arguments"] = args.is_string() ? args.get<std::string>() : args.dump(); // OpenAI: string
+        calls.push_back(std::move(call));
+        idx++;
+    }
+    return calls;
+}
+
 bool handle_api_messages(const nlohmann::json &messages, std::vector<Content> &history,
                          std::vector<MediaInputs> *media_inputs = nullptr,
                          std::vector<std::string> *temp_files = nullptr)
@@ -1981,10 +2034,41 @@ bool handle_api_messages(const nlohmann::json &messages, std::vector<Content> &h
         {
             content.role = ASSISTANT;
         }
+        else if (item.contains("role") && item["role"] == "tool")
+        {
+            // OpenAI tool result -> Qwen3 renders it as a user turn wrapped in <tool_response>.
+            std::string tc = item.contains("content")
+                                 ? (item["content"].is_string() ? item["content"].get<std::string>() : item["content"].dump())
+                                 : std::string();
+            history.push_back({USER, TEXT, std::string("<tool_response>\n") + tc + "\n</tool_response>"});
+            continue;
+        }
         else
         {
             ALOGE("content type not support");
             return false;
+        }
+        // assistant turn that itself made tool calls -> render them back as <tool_call> text
+        if (content.role == ASSISTANT && item.contains("tool_calls") && item["tool_calls"].is_array())
+        {
+            std::string tc;
+            for (const auto &call : item["tool_calls"])
+            {
+                if (!call.contains("function") || !call["function"].is_object()) continue;
+                nlohmann::json one;
+                one["name"] = call["function"].value("name", std::string());
+                nlohmann::json args = nlohmann::json::object();
+                if (call["function"].contains("arguments"))
+                {
+                    const auto &a = call["function"]["arguments"];
+                    if (a.is_string()) { try { args = nlohmann::json::parse(a.get<std::string>()); } catch (...) {} }
+                    else args = a;
+                }
+                one["arguments"] = args;
+                if (!tc.empty()) tc += "\n";
+                tc += std::string("<tool_call>\n") + one.dump() + "\n</tool_call>";
+            }
+            if (!tc.empty()) { history.push_back({ASSISTANT, TEXT, tc}); continue; }
         }
 
         std::vector<std::string> media_uris;
@@ -2528,6 +2612,15 @@ int run_server_mode(const ModelConfig &config, int port)
                     push_chat_error("invalid_request_error", "Failed to parse chat messages.");
                     return;
                 }
+                // Native tool calling (Qwen3): append the request's tools to the system prompt.
+                const bool req_has_tools = req.raw.contains("tools") && req.raw["tools"].is_array() && !req.raw["tools"].empty();
+                if (req_has_tools) {
+                    const std::string tools_section = render_qwen3_tools_section(req.raw["tools"]);
+                    if (!history.empty() && history.front().role == SYSTEM)
+                        history.front().data += tools_section;
+                    else
+                        history.insert(history.begin(), {SYSTEM, TEXT, std::string("You are a helpful assistant.") + tools_section});
+                }
                 // serve mode does NOT inject config.system_prompt: the client controls the
                 // system message (OpenAI-compatible — no system message means no system block).
                 // config.system_prompt only applies to interactive `run` mode.
@@ -2647,6 +2740,10 @@ int run_server_mode(const ModelConfig &config, int port)
                         final_text = wrap_thinking_text_for_client(final_text);
                     }
                     auto chunk = openai_api::OutputChunk::FinalText(final_text, req.model);
+                    if (req_has_tools) {
+                        nlohmann::json tcs = parse_tool_calls_from_text(out_history.back().data);
+                        if (!tcs.empty()) chunk.obj["tool_calls"] = tcs;
+                    }
                     fprintf(stdout, "%s", final_text.c_str());
                     fflush(stdout);
                     provider->push(chunk);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1961,21 +1961,6 @@ static void infer_media_type_from_uri_prefix(std::string &raw_url, ContentType &
 
 // Handle HTTP API messages
 // ---------------- Native tool calling (Qwen3 <tool_call> format) ----------------
-// Render an OpenAI "tools" array into the Qwen3 system-prompt tool section.
-static std::string render_qwen3_tools_section(const nlohmann::json &tools)
-{
-    if (!tools.is_array() || tools.empty()) return {};
-    std::string s;
-    s += "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\n";
-    s += "You are provided with function signatures within <tools></tools> XML tags:\n<tools>";
-    for (const auto &t : tools) s += "\n" + t.dump();
-    s += "\n</tools>\n\n";
-    s += "For each function call, return a json object with function name and arguments within "
-         "<tool_call></tool_call> XML tags:\n<tool_call>\n"
-         "{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call>";
-    return s;
-}
-
 // Extract <tool_call>{...}</tool_call> blocks from model output -> OpenAI tool_calls array.
 static nlohmann::json parse_tool_calls_from_text(const std::string &text)
 {
@@ -2625,16 +2610,19 @@ int run_server_mode(const ModelConfig &config, int port)
                     }
                 }
                 const bool tools_active = req_has_tools && tool_choice_mode != "none";
+                // The tokenizer renders the tool section into the prompt (per-model format);
+                // set/clear it every request so tools don't leak into the next one.
+                llm.SetTools(tools_active ? req.raw["tools"].dump() : std::string());
                 if (tools_active) {
-                    std::string tools_section = render_qwen3_tools_section(req.raw["tools"]);
+                    // tool_choice forcing: append an instruction to the last user turn
+                    // (no history/media-index mutation).
+                    std::string force;
                     if (tool_choice_mode == "required")
-                        tools_section += "\n\nYou MUST call one of the provided functions to answer. Do not answer in plain text.";
+                        force = "\n\nYou MUST call one of the provided functions to answer. Do not answer in plain text.";
                     else if (tool_choice_mode == "function" && !forced_tool_name.empty())
-                        tools_section += std::string("\n\nYou MUST call the function \"") + forced_tool_name + "\" to answer. Do not answer in plain text.";
-                    if (!history.empty() && history.front().role == SYSTEM)
-                        history.front().data += tools_section;
-                    else
-                        history.insert(history.begin(), {SYSTEM, TEXT, std::string("You are a helpful assistant.") + tools_section});
+                        force = std::string("\n\nYou MUST call the function \"") + forced_tool_name + "\" to answer. Do not answer in plain text.";
+                    if (!force.empty() && !history.empty() && history.back().role == USER)
+                        history.back().data += force;
                 }
                 // serve mode does NOT inject config.system_prompt: the client controls the
                 // system message (OpenAI-compatible — no system message means no system block).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1981,10 +1981,13 @@ static nlohmann::json parse_tool_calls_from_text(const std::string &text)
         if (b == std::string::npos) break;
         std::string body = text.substr(a + open.size(), b - (a + open.size()));
         pos = b + close.size();
-        size_t s0 = body.find_first_not_of(" \t\r\n");
-        size_t s1 = body.find_last_not_of(" \t\r\n");
-        if (s0 == std::string::npos) continue;
-        body = body.substr(s0, s1 - s0 + 1);
+        // Extract the outermost {...} object. Some models prefix/suffix the JSON
+        // with stray tag artifacts (e.g. a doubled '>' -> "<tool_call>>") or
+        // whitespace; anchoring on the braces keeps those from breaking parsing.
+        size_t j0 = body.find('{');
+        size_t j1 = body.rfind('}');
+        if (j0 == std::string::npos || j1 == std::string::npos || j1 < j0) continue;
+        body = body.substr(j0, j1 - j0 + 1);
         nlohmann::json obj;
         try { obj = nlohmann::json::parse(body); } catch (...) { continue; }
         std::string name = obj.value("name", std::string());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,8 +73,14 @@
 #endif
 
 // Global variables
+#include <mutex>
 static LLM g_llm;
 static openai_api::Server g_server;
+// serve is single-flight: routeChat/Embedding/ASR run each request on a DETACHED
+// thread, and the HTTP concurrency slot is released early on timeout/disconnect, so
+// two llm.Run calls can otherwise overlap and corrupt the shared engine state.
+// Serialize all engine work here so concurrent requests queue instead of colliding.
+static std::mutex g_engine_mutex;
 static std::atomic<bool> g_running{true};
 // In interactive mode: SIGINT/Ctrl+C stops current generation and returns to prompt.
 // In server mode: SIGINT/Ctrl+C exits the process (by stopping server loop).
@@ -2278,6 +2284,7 @@ int run_server_mode(const ModelConfig &config, int port)
             g_server.registerImageGeneration(variant.model_id, [generator, generated_dir](const openai_api::ImageGenRequest &req,
                                                                                            std::shared_ptr<openai_api::BaseDataProvider> provider)
                                              {
+                std::lock_guard<std::mutex> engine_lock(g_engine_mutex); // single-flight: no overlapping engine work
                 if (!provider->is_writable()) {
                     ALOGE("provider not writable");
                     return;
@@ -2374,6 +2381,7 @@ int run_server_mode(const ModelConfig &config, int port)
             timeout_ms = 300000;
         }
         g_server.setTimeout(std::chrono::milliseconds(timeout_ms));
+        g_server.setWaitTimeout(std::chrono::milliseconds(timeout_ms)); // single-flight: queued requests wait up to the request timeout, not 503 after the 5s default
         g_server.run(port);
     }
     else
@@ -2397,6 +2405,7 @@ int run_server_mode(const ModelConfig &config, int port)
             g_server.registerEmbedding(model_name, [&llm, use_jina_prompt_prefix](const openai_api::EmbeddingRequest &req,
                                                                std::shared_ptr<openai_api::BaseDataProvider> provider)
                                        {
+                std::lock_guard<std::mutex> engine_lock(g_engine_mutex); // single-flight: no overlapping engine work
                 if (!provider->is_writable()) {
                     ALOGE("provider not writable");
                     return;
@@ -2500,6 +2509,7 @@ int run_server_mode(const ModelConfig &config, int port)
                 timeout_ms = 300000;
             }
             g_server.setTimeout(std::chrono::milliseconds(timeout_ms));
+        g_server.setWaitTimeout(std::chrono::milliseconds(timeout_ms)); // single-flight: queued requests wait up to the request timeout, not 503 after the 5s default
             g_server.run(port);
         }
         else
@@ -2521,6 +2531,7 @@ int run_server_mode(const ModelConfig &config, int port)
             g_server.registerChat(model_name, [&llm, config, single_image_ocr_mode, hymt_translation_mode](const openai_api::ChatRequest &req,
                                                                                                             std::shared_ptr<openai_api::BaseDataProvider> provider)
                                   {
+                std::lock_guard<std::mutex> engine_lock(g_engine_mutex); // single-flight: no overlapping engine work
                 if (!provider->is_writable()) {
                     ALOGE("provider not writable");
                     return;
@@ -2778,6 +2789,7 @@ int run_server_mode(const ModelConfig &config, int port)
                 g_server.registerASR(model_name, [&llm](const openai_api::ASRRequest &req,
                                                         std::shared_ptr<openai_api::BaseDataProvider> provider)
                                      {
+                    std::lock_guard<std::mutex> engine_lock(g_engine_mutex); // single-flight: no overlapping engine work
                     if (!provider->is_writable()) {
                         ALOGE("provider not writable");
                         return;
@@ -2844,6 +2856,7 @@ int run_server_mode(const ModelConfig &config, int port)
                 timeout_ms = 300000;
             }
             g_server.setTimeout(std::chrono::milliseconds(timeout_ms));
+        g_server.setWaitTimeout(std::chrono::milliseconds(timeout_ms)); // single-flight: queued requests wait up to the request timeout, not 503 after the 5s default
             g_server.run(port);
         }
         llm.Deinit();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2612,10 +2612,25 @@ int run_server_mode(const ModelConfig &config, int port)
                     push_chat_error("invalid_request_error", "Failed to parse chat messages.");
                     return;
                 }
-                // Native tool calling (Qwen3): append the request's tools to the system prompt.
+                // Native tool calling (Qwen3): honor tool_choice + append tools to the system prompt.
                 const bool req_has_tools = req.raw.contains("tools") && req.raw["tools"].is_array() && !req.raw["tools"].empty();
-                if (req_has_tools) {
-                    const std::string tools_section = render_qwen3_tools_section(req.raw["tools"]);
+                std::string tool_choice_mode = "auto";
+                std::string forced_tool_name;
+                if (req.raw.contains("tool_choice")) {
+                    const auto &tc = req.raw["tool_choice"];
+                    if (tc.is_string()) tool_choice_mode = tc.get<std::string>();
+                    else if (tc.is_object() && tc.contains("function") && tc["function"].is_object()) {
+                        tool_choice_mode = "function";
+                        forced_tool_name = tc["function"].value("name", std::string());
+                    }
+                }
+                const bool tools_active = req_has_tools && tool_choice_mode != "none";
+                if (tools_active) {
+                    std::string tools_section = render_qwen3_tools_section(req.raw["tools"]);
+                    if (tool_choice_mode == "required")
+                        tools_section += "\n\nYou MUST call one of the provided functions to answer. Do not answer in plain text.";
+                    else if (tool_choice_mode == "function" && !forced_tool_name.empty())
+                        tools_section += std::string("\n\nYou MUST call the function \"") + forced_tool_name + "\" to answer. Do not answer in plain text.";
                     if (!history.empty() && history.front().role == SYSTEM)
                         history.front().data += tools_section;
                     else
@@ -2666,6 +2681,7 @@ int run_server_mode(const ModelConfig &config, int port)
                     auto callback = [provider,
                                      model_id = req.model,
                                      emit_thinking_markup,
+                                     tools_active,
                                      &streamed_any,
                                      &thinking_open_emitted,
                                      &streamed_text](std::string str, float token_per_sec, void *reserve) {
@@ -2673,6 +2689,7 @@ int run_server_mode(const ModelConfig &config, int port)
                             ALOGE("provider not writable");
                             return;
                         }
+                        if (tools_active) { streamed_text += str; return; } // buffer; decide after generation
                         std::string out = str;
                         if (emit_thinking_markup)
                         {
@@ -2704,7 +2721,23 @@ int run_server_mode(const ModelConfig &config, int port)
                             provider->push(openai_api::OutputChunk::Error("model_error", llm_error));
                         }
                     }
-                    if (streamed_any) {
+                    if (tools_active) {
+                        if (llm_error.empty()) {
+                            nlohmann::json tcs = parse_tool_calls_from_text(streamed_text);
+                            if (!tcs.empty()) {
+                                auto d = openai_api::OutputChunk::TextDelta("", req.model);
+                                d.obj["tool_calls"] = tcs;
+                                provider->push(d);
+                                auto fin = openai_api::OutputChunk::FinalText("", req.model);
+                                fin.obj["finish_reason"] = "tool_calls";
+                                provider->push(fin);
+                            } else {
+                                std::string out = emit_thinking_markup ? wrap_thinking_text_for_client(streamed_text) : streamed_text;
+                                if (!out.empty()) provider->push(openai_api::OutputChunk::TextDelta(out, req.model));
+                                provider->push(openai_api::OutputChunk::FinalText("", req.model));
+                            }
+                        }
+                    } else if (streamed_any) {
                         if (emit_thinking_markup && thinking_open_emitted && !has_thinking_close_tag(streamed_text))
                         {
                             provider->push(openai_api::OutputChunk::TextDelta("\n</think>", req.model));
@@ -2740,7 +2773,7 @@ int run_server_mode(const ModelConfig &config, int port)
                         final_text = wrap_thinking_text_for_client(final_text);
                     }
                     auto chunk = openai_api::OutputChunk::FinalText(final_text, req.model);
-                    if (req_has_tools) {
+                    if (tools_active) {
                         nlohmann::json tcs = parse_tool_calls_from_text(out_history.back().data);
                         if (!tcs.empty()) chunk.obj["tool_calls"] = tcs;
                     }

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -393,8 +393,6 @@ struct LLM::Impl {
     struct LLMLayer {
         ax_runner_t layer;
         std::string filename;
-        MMap layer_buffer;
-        std::vector<char> layer_buffer_vec;
     };
 
     std::vector<LLMLayer> llama_layers;
@@ -2519,12 +2517,9 @@ struct LLM::Impl {
         int host_mb = 0;
         if (!_attr.b_use_mmap_load_embed)
             host_mb += estimate_model_mb(_attr.filename_tokens_embed);
-        if (_attr.hidden_size_per_layer_input > 0)
-        {
-            host_mb += estimate_model_mb(_attr.filename_tokens_embed_per_layer);
-            host_mb += estimate_model_mb(_attr.filename_per_layer_model_projection);
-            host_mb += estimate_model_mb(_attr.filename_per_layer_projection_norm);
-        }
+        // Gemma per-layer embed/projection files are mmap'd (demand-paged) by Gemma4PerLayerHelper,
+        // NOT read into resident host RAM, so they must not be counted as a host DDR load (they used to
+        // false-abort gemma-4 on the host path -- the ~4.5GB per-layer embed dwarfs real DDR).
         if (host_mb > 0 && !guard_host_load("host: token-embedding / per-layer weights", host_mb))
             return false;
 
@@ -3754,6 +3749,7 @@ struct LLM::Impl {
 
     void ResetKVCache()
     {
+        gemma4_per_layer_helper.ClearDecodeCache();
         last_tokens_ids.clear(); last_history_snapshot.clear(); run_input_token_ids.clear(); last_run_generated_token_ids.clear(); k_caches.clear(); v_caches.clear(); linear_state_snapshots_.clear(); precompute_len = 0; cached_mrope_next_pos = -1; active_prefill_pos_start = -1; active_token_pos_start = -1; reset_full_cache_slot_state();
         decode_grpid = decode_grpids_.empty() ? 0 : decode_grpids_.back();
         _attr.prefill_grpid = prefill_grpids_.empty() ? 1 : prefill_grpids_.back();

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -5628,6 +5628,7 @@ LLaMaEmbedSelector *LLM::getEmbedSelector() { return &impl_->embed_selector; }
 void LLM::SetRequestSamplingOverride(bool has_temperature, float temperature, bool has_top_p, float top_p, bool has_frequency_penalty, float frequency_penalty, bool has_presence_penalty, float presence_penalty) { impl_->postprocess.set_request_sampling_override(has_temperature, temperature, has_top_p, top_p, has_frequency_penalty, frequency_penalty, has_presence_penalty, presence_penalty); }
 void LLM::ClearRequestSamplingOverride() { impl_->postprocess.clear_request_sampling_override(); }
 void LLM::SetRequestThinkingMode(ThinkingMode mode) { if (impl_->tokenizer) impl_->tokenizer->set_generation_thinking_mode(mode); }
+void LLM::SetTools(const std::string &tools_json) { if (impl_->tokenizer) impl_->tokenizer->set_tools(tools_json); }
 void LLM::ClearRequestThinkingMode() { if (impl_->tokenizer) impl_->tokenizer->set_generation_thinking_mode(impl_->_attr.generation_thinking_mode); }
 bool LLM::TokenizerSupportsThinkingToggle() const { return impl_->tokenizer ? impl_->tokenizer->supports_thinking_toggle() : false; }
 void LLM::MarkRequestStart() { impl_->MarkRequestStart(); }

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -86,7 +86,7 @@ struct LLMAttrType {
     std::vector<int> prefill_max_kv_cache_num_grp;
     int prefill_grpid = -1;
     std::string post_config_path = "post_config.json";
-    bool b_use_mmap_load_embed = false;
+    bool b_use_mmap_load_embed = true; // default to mmap (demand-paged); avoids loading the whole embed table into host RAM
 
     // ---- vision / VLM (optional, runtime switch by `vlm_type`) ----
     // If `vlm_type != VLMType::None`, vision encoder will be initialized and used.

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -142,6 +142,7 @@ public:
     void ClearRequestSamplingOverride();
     void SetRequestThinkingMode(ThinkingMode mode);
     void ClearRequestThinkingMode();
+    void SetTools(const std::string &tools_json); // forward the request's OpenAI tools to the tokenizer
     // True if the active tokenizer actually honors think/no_think in its prompt
     // (so callers can warn when a mode is requested but would be ignored).
     bool TokenizerSupportsThinkingToggle() const;

--- a/src/runner/LLMPostprocess.hpp
+++ b/src/runner/LLMPostprocess.hpp
@@ -59,6 +59,7 @@ private:
     // 	控制随机性
     void apply_temperature(std::vector<float> &logits, float temperature)
     {
+        if (temperature < 1e-2f) temperature = 1e-2f; // avoid inf/NaN from a near-zero temperature
         for (float &logit : logits)
         {
             logit /= temperature;
@@ -555,7 +556,7 @@ public:
 
         enable_temperature = config["enable_temperature"];
         temperature = config["temperature"];
-        if (temperature <= 0.0f) temperature = 1.0f;
+        if (temperature < 0.0f) temperature = 0.0f; // temperature 0 = greedy; do NOT rewrite to 1.0 (that turns a determinism request into random sampling)
 
         enable_repetition_penalty = config["enable_repetition_penalty"];
         repetition_penalty = config["repetition_penalty"];

--- a/src/runner/ax_model_runner/ax_model_runner_axcl.cpp
+++ b/src/runner/ax_model_runner/ax_model_runner_axcl.cpp
@@ -484,7 +484,7 @@ int ax_runner_axcl::init(const char *model_file, int devid)
     {
         m_handle = new ax_joint_runner_ax650_handle_t;
     }
-    memset(m_handle, 0, sizeof(ax_joint_runner_ax650_handle_t));
+    *m_handle = ax_joint_runner_ax650_handle_t{}; // value-init: safely resets the std::vector<ios> member (memset would corrupt its control block)
     this->dev_id = devid;
 
     int ret = axcl_EngineLoadFromFile(model_file, &m_handle->handle, dev_id);
@@ -569,7 +569,7 @@ int ax_runner_axcl::init(char *model_buffer, size_t model_size, int devid)
     {
         m_handle = new ax_joint_runner_ax650_handle_t;
     }
-    memset(m_handle, 0, sizeof(ax_joint_runner_ax650_handle_t));
+    *m_handle = ax_joint_runner_ax650_handle_t{}; // value-init: safely resets the std::vector<ios> member (memset would corrupt its control block)
     this->dev_id = devid;
 
     void *devMem = nullptr;


### PR DESCRIPTION
feat: 原生工具调用 + 主分支审查修复 + 并发安全

本分支从 axllm 拉出,含三块相对独立的工作,已一起测好、等一期合并。

概述

- 新增:OpenAI 兼容的原生工具/函数调用(Qwen3 系,文本 + VLM)。
- 修复:一批"feature 累积引入的不合理资源/行为"问题(审查发现)。
- 修复:并发请求会踩烂共享引擎的严重问题(serve 现在是真·单飞)。

---
1. 原生工具调用(Tool / Function Calling)

在 serve 里支持 tools / tool_choice 请求、返回 tool_calls、多轮工具结果回传、流式、以及 VLM(图+工具)。

- 输入:读 req.raw["tools"],由 tokenizer 按模型自己的模板渲染工具段(Qwen3Tokenizer);role:"tool"→<tool_response>。
- 输出:从生成里解析 <tool_call>{...}</tool_call> → 组装 OpenAI tool_calls(编码器新增支持)。
- tool_choice:auto / none / required / 指定函数。
- 文档:docs/tool_calling.md(明确仅支持 Qwen3 系;其他模型族回落为纯文本)。

测试(AXCL + qwen3-1.7b / qwen3-vl-2b):稳定性 19/20(95%,唯一失败是 1.7B 偶尔不调工具,required 可兜底);流式 3/3;tool_choice 3/4;VLM 3/3。

2. 主分支审查修复(资源 / 行为)

一批低风险修复(同 m_model_buffer 那类"不合理"):
- mem-guard 不再把 gemma4 的 mmap per-layer embed(~4.5GB)当 host DDR → 除掉 gemma-4 host 路径的误拦。
- gemma4 per-token decode 缓存在 ResetKVCache 清空(原先无上限、长 serve 持续涨)。
- embed 默认走 mmap(不设 flag 的 config 不再把整张 embed 表读进 RAM)。
- temperature:0 = greedy(原先被静默改写成 1.0 → 变随机);近零 temperature 夹紧防 inf/NaN。
- AXCL memset 结构体 → value-init(修 std::vector 控制块损坏);--port/--server_timeout_ms 加异常保护;删死成员 layer_buffer*。

3. 并发安全(真·单飞)

问题:serve 本意单飞,但 openai-api 给每个请求 detached 线程跑 llm.Run,HTTP 并发闸在超时/断连时会提前释放,导致两个 llm.Run 在共享引擎上重叠 → KV/状态踩烂;且 setWaitTimeout 从未被调用,排队 5s 就 503。
修复:全局 g_engine_mutex 锁住每个 handler 的引擎工作(永不重叠);补上 setWaitTimeout(server_timeout_ms)。
实测:8 个并发(流式/非流式混合)修复前 5/8(3×503)→ 修复后 8/8 全对、无串答、server 稳定。

---
依赖的子模块改动(已推各自主线)

- openai-api.cpp(master):44b493d 响应 tool_calls、14db1ad 流式 delta.tool_calls。
- tokenizer.axera(main):71173a9 Qwen3 渲染工具段。
- 本分支已 bump 两个子模块指针。