### PR TITLE
fix(kv-cache): reuse instead of full recompute on identical re-query …

### DIFF
--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -5518,7 +5518,28 @@ struct LLM::Impl {
                 ALOGE("cached media turn has empty token diff; refuse full recompute");
                 return history;
             }
-            if (!new_tokens.empty()) { precompute_len = (int)new_tokens.size() - 1; offset = precompute_len; tokens_diff = {new_tokens.back()}; }
+            if (!new_tokens.empty())
+            {
+                // Identical re-query: the reused prefix is the whole previous input minus one
+                // token. Chunk-align + cap it to the prefill history capacity so it fits a
+                // single prefill group and can be reused (otherwise SetKVCache would fail and
+                // fall back to a full recompute). Linear models keep the exact value and rely
+                // on the fallback (their state is snapshotted, not chunk-addressable).
+                int keep = (int)new_tokens.size() - 1;
+                if (!has_linear_attention_layers())
+                {
+                    const int step = std::max(1, _attr.prefill_token_num);
+                    const int maxh = max_prefill_history_cap();
+                    if (maxh > 0 && keep > maxh) keep = maxh;
+                    keep = (keep / step) * step;
+                    if (keep < 0) keep = 0;
+                }
+                precompute_len = keep;
+                offset = keep;
+                tokens_diff.assign(new_tokens.begin() + keep, new_tokens.end());
+                if ((int)last_tokens_ids.size() > keep) last_tokens_ids.resize((size_t)keep);
+                ALOGI("identical re-query: reuse KV prefix tokens=%d recompute_suffix=%zu", keep, tokens_diff.size());
+            }
             else { ResetKVCache(); precompute_len = 0; }
         }
         if (!not_append && offset != precompute_len && precompute_len > 0)


### PR DESCRIPTION
…at capacity

Corner case (customer): when the prefill cache is near capacity and the exact same prompt is sent again, the token diff is empty (rollback), so the tokens_diff.empty() branch set precompute_len = new_tokens.size()-1 without chunk-aligning/capping it. That prefix exceeds the prefill history capacity, SetKVCache fails, and it fell back to a full recompute (correct answer, but slow). A slightly different prompt was fine because it takes the already-chunk-aligned reuse path.

Apply the same chunk-align + history-capacity cap to the empty-suffix path (non-linear; linear keeps the exact value and relies on the fallback). Now the reused prefix is chunk-aligned to <= max_prefill_history_cap and reuse succeeds.

Verified on AXCL, Qwen3-0.6B: ~2100-tok prompt then identical re-query x2 -> reuse (recompute suffix = 77 tokens, was a full 2125-token recompute), correct answers, no fall-back / no invalid prefill_grpid.