### PR TITLE
fix(serve): populate usage token counts in chat completions

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2618,7 +2618,11 @@ int run_server_mode(const ModelConfig &config, int port)
                             fprintf(stdout, "%s", "\n</think>");
                             fflush(stdout);
                         }
-                        provider->push(openai_api::OutputChunk::FinalText("", req.model));
+                        auto final_chunk = openai_api::OutputChunk::FinalText("", req.model);
+                        final_chunk.usage.prompt_tokens = llm.GetLastPromptTokenNum();
+                        final_chunk.usage.completion_tokens = llm.GetLastCompletionTokenNum();
+                        final_chunk.usage.total_tokens = final_chunk.usage.prompt_tokens + final_chunk.usage.completion_tokens;
+                        provider->push(final_chunk);
                     }
                 } else {
                     llm.getAttr()->runing_callback = nullptr;
@@ -2647,6 +2651,9 @@ int run_server_mode(const ModelConfig &config, int port)
                         final_text = wrap_thinking_text_for_client(final_text);
                     }
                     auto chunk = openai_api::OutputChunk::FinalText(final_text, req.model);
+                    chunk.usage.prompt_tokens = llm.GetLastPromptTokenNum();
+                    chunk.usage.completion_tokens = llm.GetLastCompletionTokenNum();
+                    chunk.usage.total_tokens = chunk.usage.prompt_tokens + chunk.usage.completion_tokens;
                     fprintf(stdout, "%s", final_text.c_str());
                     fflush(stdout);
                     provider->push(chunk);

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -337,6 +337,9 @@ struct LLM::Impl {
     std::vector<int> last_tokens_ids;
     std::vector<int> run_input_token_ids;
     std::vector<int> last_run_generated_token_ids;
+    int last_run_prompt_token_num_ = 0;
+    int get_last_prompt_token_num() const { return last_run_prompt_token_num_; }
+    int get_last_completion_token_num() const { return (int)last_run_generated_token_ids.size(); }
     std::vector<std::vector<unsigned short>> k_caches, v_caches;
     struct LinearStateSnapshot {
         int token_len = 0;
@@ -5322,6 +5325,7 @@ struct LLM::Impl {
             new_tokens = tokenizer->encode(history);
         }
 
+        last_run_prompt_token_num_ = (int)new_tokens.size();
         int offset = 0;
         auto tokens_diff = diff_token_ids(last_tokens_ids, new_tokens, offset);
         const bool token_appended = (offset == (int)last_tokens_ids.size() && (int)new_tokens.size() >= (int)last_tokens_ids.size());
@@ -5699,6 +5703,8 @@ bool LLM::TokenizerSupportsThinkingToggle() const { return impl_->tokenizer ? im
 void LLM::MarkRequestStart() { impl_->MarkRequestStart(); }
 void LLM::ClearRequestStart() { impl_->ClearRequestStart(); }
 std::string LLM::GetLastError() const { return impl_->get_last_error(); }
+int LLM::GetLastPromptTokenNum() const { return impl_->get_last_prompt_token_num(); }
+int LLM::GetLastCompletionTokenNum() const { return impl_->get_last_completion_token_num(); }
 
 bool LLM::Embed(const std::string &text, std::vector<float> &out_embedding) { return impl_->EmbedText(text, out_embedding); }
 bool LLM::Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding) { return impl_->EmbedHistory(history, media_inputs, out_embedding); }

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -148,6 +148,8 @@ public:
     void MarkRequestStart();
     void ClearRequestStart();
     std::string GetLastError() const;
+    int GetLastPromptTokenNum() const;
+    int GetLastCompletionTokenNum() const;
 
     bool Embed(const std::string &text, std::vector<float> &out_embedding);
     bool Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding);


### PR DESCRIPTION
The OpenAI-compatible chat endpoint always returned usage.{prompt_tokens,completion_tokens,total_tokens} = 0 because OutputChunk.usage was never filled in.

Track the full input prompt length (new_tokens.size(), before KV-reuse diffing) and the generated token count (last_run_generated_token_ids), expose them via LLM::GetLastPromptTokenNum()/GetLastCompletionTokenNum(), and set them on the FinalText chunk for both the streaming (final SSE chunk) and non-streaming responses.