### PR TITLE
fix(serve): do not crash on missing keys in post_config.json (#63)

### DIFF
--- a/src/runner/LLMPostprocess.hpp
+++ b/src/runner/LLMPostprocess.hpp
@@ -553,23 +553,27 @@ public:
         nlohmann::json config = nlohmann::json::parse(config_file);
         ALOGI("load config: \n%s\n", config.dump(4).c_str());
 
-        enable_temperature = config["enable_temperature"];
-        temperature = config["temperature"];
+        // Missing keys must not crash: nlohmann operator[] returns null for an
+        // absent key, and converting null -> bool/number throws type_error.302.
+        // Use value(key, default) so an incomplete post_config.json degrades
+        // gracefully (same approach as the frequency/presence penalties below).
+        enable_temperature = config.value("enable_temperature", false);
+        temperature = config.value("temperature", 1.0f);
         if (temperature <= 0.0f) temperature = 1.0f;
 
-        enable_repetition_penalty = config["enable_repetition_penalty"];
-        repetition_penalty = config["repetition_penalty"];
-        penalty_window = config["penalty_window"];
+        enable_repetition_penalty = config.value("enable_repetition_penalty", false);
+        repetition_penalty = config.value("repetition_penalty", 1.0f);
+        penalty_window = config.value("penalty_window", 20);
         if (penalty_window < 0) penalty_window = 0;
         if (repetition_penalty < 0.0f) repetition_penalty = 1.0f;
 
-        enable_top_p_sampling = config["enable_top_p_sampling"];
-        top_p = config["top_p"];
+        enable_top_p_sampling = config.value("enable_top_p_sampling", false);
+        top_p = config.value("top_p", 1.0f);
         if (top_p <= 0.0f) top_p = 0.9f; // reasonable default
         if (top_p > 1.0f) top_p = 1.0f;
 
-        enable_top_k_sampling = config["enable_top_k_sampling"];
-        top_k = config["top_k"];
+        enable_top_k_sampling = config.value("enable_top_k_sampling", false);
+        top_k = config.value("top_k", 1);
         if (top_k < 1) top_k = 1;
 
         // Optional OpenAI-style penalties. Backward compatible: absent keys ->


### PR DESCRIPTION
load_config() read the sampling keys with config["key"], which returns a null JSON value for an absent key; converting that null to bool/number throws [json.exception.type_error.302] and aborts the process after the model is already allocated.

Read them with the null-safe config.value(key, default) instead (the same pattern already used for the frequency/presence penalties just below), so an incomplete post_config.json degrades to sane defaults instead of crashing. Verified against the real load_config: an incomplete file (only "temperature") and an empty {} now load cleanly.