### PR TITLE
fix(serve): release CMM pool on SIGTERM/SIGHUP/SIGQUIT (#60)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2797,6 +2797,15 @@ int main(int argc, char *argv[])
     signal(SIGPIPE, SIG_IGN);
 #endif
     signal(SIGINT, __sigExit);
+#ifndef _WIN32
+    // Also shut down gracefully on `kill`/`killall` (SIGTERM), terminal hangup
+    // (SIGHUP) and SIGQUIT so run_server_mode() unwinds to LLM.Deinit() and
+    // frees the CMM pool. On on-chip targets /dev/ax_cmm is not reclaimed on an
+    // ungraceful exit, so an unhandled SIGTERM leaks the pool until reboot (#60).
+    signal(SIGTERM, __sigExit);
+    signal(SIGHUP, __sigExit);
+    signal(SIGQUIT, __sigExit);
+#endif
 #ifdef _WIN32
     SetConsoleCtrlHandler(__ConsoleCtrlHandler, TRUE);
     // Initialize logger early so Windows console uses UTF-8 (prevents Chinese/box-drawing garbling).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2322,6 +2322,16 @@ int run_server_mode(const ModelConfig &config, int port)
             return -1;
         }
 
+        // Safety net: free the model's CMM pool on every path that unwinds this
+        // scope -- normal return, signal-triggered shutdown, or an uncaught
+        // exception. Deinit() is idempotent (guarded by deinited_), so the
+        // explicit Deinit() on the normal path below stays a no-op here. (#60)
+        struct LlmCmmGuard
+        {
+            LLM &llm;
+            ~LlmCmmGuard() { llm.Deinit(); }
+        } llm_cmm_guard{llm};
+
         if (config.is_embedding_model())
         {
             const bool use_jina_prompt_prefix = normalized_key(config.attr.tokenizer_type) == "qwen3omni";
@@ -2898,7 +2908,17 @@ int main(int argc, char *argv[])
                 return 0;
             }
         }
-        return run_server_mode(config, port);
+        try
+        {
+            return run_server_mode(config, port);
+        }
+        catch (const std::exception &e)
+        {
+            // Unwind the stack (running LlmCmmGuard -> Deinit -> CMM freed)
+            // instead of std::terminate skipping destructors on an uncaught throw.
+            ALOGE("serve terminated by exception: %s", e.what());
+            return -1;
+        }
     }
     else
     {


### PR DESCRIPTION
Only SIGINT was wired to __sigExit, which stops the server loop so run_server_mode() unwinds to LLM.Deinit() and frees the CMM pool. A plain kill/killall sends SIGTERM, which had no handler: the process was terminated with Deinit() never running. On on-chip targets /dev/ax_cmm does not reclaim on ungraceful exit, so the 8GB pool stayed locked until reboot (AXCL/PCIe masks this because the host driver reclaims on process death).

Route SIGTERM, SIGHUP and SIGQUIT through the same graceful handler (POSIX-only; Windows keeps its console-ctrl handler). Verified on AXCL: before the fix a SIGTERM produced no shutdown log; after, it logs [cmm-sentry] Deinit: CMM balanced + AXCLWorker exit, i.e. Deinit() runs.

Note: SIGKILL (uncatchable) and hard crashes (SIGSEGV) still cannot run Deinit safely and rely on driver/OS reclaim.