### PR TITLE
feat(serve): expose TTFT and decode speed in OpenAI usage

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2639,6 +2639,8 @@ int run_server_mode(const ModelConfig &config, int port)
                         final_chunk.usage.prompt_tokens = llm.GetLastPromptTokenNum();
                         final_chunk.usage.completion_tokens = llm.GetLastCompletionTokenNum();
                         final_chunk.usage.total_tokens = final_chunk.usage.prompt_tokens + final_chunk.usage.completion_tokens;
+                        final_chunk.usage.ttft_ms = llm.GetLastTtftMs();
+                        final_chunk.usage.decode_tps = llm.GetLastDecodeTps();
                         provider->push(final_chunk);
                     }
                 } else {
@@ -2671,6 +2673,8 @@ int run_server_mode(const ModelConfig &config, int port)
                     chunk.usage.prompt_tokens = llm.GetLastPromptTokenNum();
                     chunk.usage.completion_tokens = llm.GetLastCompletionTokenNum();
                     chunk.usage.total_tokens = chunk.usage.prompt_tokens + chunk.usage.completion_tokens;
+                    chunk.usage.ttft_ms = llm.GetLastTtftMs();
+                    chunk.usage.decode_tps = llm.GetLastDecodeTps();
                     fprintf(stdout, "%s", final_text.c_str());
                     fflush(stdout);
                     provider->push(chunk);

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -24,6 +24,8 @@ void LLM::ClearRequestStart() { impl_->ClearRequestStart(); }
 std::string LLM::GetLastError() const { return impl_->get_last_error(); }
 int LLM::GetLastPromptTokenNum() const { return impl_->get_last_prompt_token_num(); }
 int LLM::GetLastCompletionTokenNum() const { return impl_->get_last_completion_token_num(); }
+float LLM::GetLastTtftMs() const { return impl_->get_last_ttft_ms(); }
+float LLM::GetLastDecodeTps() const { return impl_->get_last_decode_tps(); }
 
 bool LLM::Embed(const std::string &text, std::vector<float> &out_embedding) { return impl_->EmbedText(text, out_embedding); }
 bool LLM::Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding) { return impl_->EmbedHistory(history, media_inputs, out_embedding); }

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -151,6 +151,9 @@ public:
     std::string GetLastError() const;
     int GetLastPromptTokenNum() const;
     int GetLastCompletionTokenNum() const;
+    // Performance metrics from the most recent Run (negative/zero = not measured).
+    float GetLastTtftMs() const;
+    float GetLastDecodeTps() const;
 
     bool Embed(const std::string &text, std::vector<float> &out_embedding);
     bool Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding);

--- a/src/runner/LLMImpl.hpp
+++ b/src/runner/LLMImpl.hpp
@@ -237,6 +237,12 @@ struct LLM::Impl : public IKvSlotHost {
     int last_run_prompt_token_num_ = 0;
     int get_last_prompt_token_num() const { return last_run_prompt_token_num_; }
     int get_last_completion_token_num() const { return (int)last_run_generated_token_ids.size(); }
+    // Performance metrics for the most recent run. -1 means "not measured this
+    // run"; consumers (OpenAI usage object) treat a negative/zero value as unset.
+    float last_run_ttft_ms_ = -1.0f;
+    float last_run_decode_tps_ = -1.0f;
+    float get_last_ttft_ms() const { return last_run_ttft_ms_; }
+    float get_last_decode_tps() const { return last_run_decode_tps_; }
     std::vector<std::vector<unsigned short>> k_caches, v_caches;
     std::vector<LinearStateSnapshot> linear_state_snapshots_;
     int precompute_len = 0;

--- a/src/runner/LLM_decode.cpp
+++ b/src/runner/LLM_decode.cpp
@@ -257,6 +257,9 @@ std::string LLM::Impl::Run(std::vector<unsigned short> &test_embed, int output_m
     ALOGI("input token num : %d, prefill_split_num : %d", input_embed_num, prefill_split_num);
     timer t_cost, ttft_timer, decode_timer; ttft_timer.start();
     bool decode_timer_started = false;
+    // Reset per-run performance metrics; assigned once measured below.
+    last_run_ttft_ms_ = -1.0f;
+    last_run_decode_tps_ = -1.0f;
 
     std::vector<int> prefill_grp_list;
     const int default_prefill_gid = prefill_grpids_.empty() ? 1 : prefill_grpids_.front();
@@ -660,6 +663,9 @@ std::string LLM::Impl::Run(std::vector<unsigned short> &test_embed, int output_m
         {
             ALOGI("ttft: %.2f ms", ttft_text_ms);
         }
+        // Store the same value reported by the "ttft:" log line above so the
+        // OpenAI usage object matches on-device measurements.
+        last_run_ttft_ms_ = (ttft_e2e_ms >= 0.0f) ? ttft_e2e_ms : ttft_text_ms;
         if (debug_prefill) ALOGI("first decode token: id=%d", next_token);
         if (next_token < 0 || next_token >= _attr.tokens_embed_num)
         {
@@ -1042,6 +1048,7 @@ std::string LLM::Impl::Run(std::vector<unsigned short> &test_embed, int output_m
         if (decode_tokens > 0 && decode_ms > 0.0f)
             avg_decode_tps = decode_tokens / (decode_ms / 1000.0f);
     }
+    last_run_decode_tps_ = avg_decode_tps;
     if (decode_profile_enabled)
     {
         const int decode_tokens = std::max(0, (int)token_ids.size() - 1);


### PR DESCRIPTION
Plumb per-run time-to-first-token (ms) and decode throughput (tokens/s) out of LLM_decode.cpp via new LLM getters (GetLastTtftMs / GetLastDecodeTps) and populate them on the streaming and non-streaming final usage chunks. Lets the lite_webui frontend display accurate, server-reported ttft_ms / decode_tps.

Bumps third_party/openai-api.cpp to local branch feat/usage-ttft-decode.