### PR TITLE
feat(serve): expose prefill speed and newly-prefilled token count in …

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2641,6 +2641,8 @@ int run_server_mode(const ModelConfig &config, int port)
                         final_chunk.usage.total_tokens = final_chunk.usage.prompt_tokens + final_chunk.usage.completion_tokens;
                         final_chunk.usage.ttft_ms = llm.GetLastTtftMs();
                         final_chunk.usage.decode_tps = llm.GetLastDecodeTps();
+                        final_chunk.usage.prefill_tps = llm.GetLastPrefillTps();
+                        final_chunk.usage.prefill_tokens = llm.GetLastPrefillTokens();
                         provider->push(final_chunk);
                     }
                 } else {
@@ -2675,6 +2677,8 @@ int run_server_mode(const ModelConfig &config, int port)
                     chunk.usage.total_tokens = chunk.usage.prompt_tokens + chunk.usage.completion_tokens;
                     chunk.usage.ttft_ms = llm.GetLastTtftMs();
                     chunk.usage.decode_tps = llm.GetLastDecodeTps();
+                    chunk.usage.prefill_tps = llm.GetLastPrefillTps();
+                    chunk.usage.prefill_tokens = llm.GetLastPrefillTokens();
                     fprintf(stdout, "%s", final_text.c_str());
                     fflush(stdout);
                     provider->push(chunk);

--- a/src/runner/LLM.cpp
+++ b/src/runner/LLM.cpp
@@ -26,6 +26,8 @@ int LLM::GetLastPromptTokenNum() const { return impl_->get_last_prompt_token_num
 int LLM::GetLastCompletionTokenNum() const { return impl_->get_last_completion_token_num(); }
 float LLM::GetLastTtftMs() const { return impl_->get_last_ttft_ms(); }
 float LLM::GetLastDecodeTps() const { return impl_->get_last_decode_tps(); }
+float LLM::GetLastPrefillTps() const { return impl_->get_last_prefill_tps(); }
+int LLM::GetLastPrefillTokens() const { return impl_->get_last_prefill_tokens(); }
 
 bool LLM::Embed(const std::string &text, std::vector<float> &out_embedding) { return impl_->EmbedText(text, out_embedding); }
 bool LLM::Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding) { return impl_->EmbedHistory(history, media_inputs, out_embedding); }

--- a/src/runner/LLM.hpp
+++ b/src/runner/LLM.hpp
@@ -154,6 +154,8 @@ public:
     // Performance metrics from the most recent Run (negative/zero = not measured).
     float GetLastTtftMs() const;
     float GetLastDecodeTps() const;
+    float GetLastPrefillTps() const;
+    int GetLastPrefillTokens() const;
 
     bool Embed(const std::string &text, std::vector<float> &out_embedding);
     bool Embed(const std::vector<Content> &history, const std::vector<MediaInputs> &media_inputs, std::vector<float> &out_embedding);

--- a/src/runner/LLMImpl.hpp
+++ b/src/runner/LLMImpl.hpp
@@ -241,8 +241,12 @@ struct LLM::Impl : public IKvSlotHost {
     // run"; consumers (OpenAI usage object) treat a negative/zero value as unset.
     float last_run_ttft_ms_ = -1.0f;
     float last_run_decode_tps_ = -1.0f;
+    float last_run_prefill_tps_ = -1.0f;
+    int last_run_prefill_tokens_ = -1;
     float get_last_ttft_ms() const { return last_run_ttft_ms_; }
     float get_last_decode_tps() const { return last_run_decode_tps_; }
+    float get_last_prefill_tps() const { return last_run_prefill_tps_; }
+    int get_last_prefill_tokens() const { return last_run_prefill_tokens_; }
     std::vector<std::vector<unsigned short>> k_caches, v_caches;
     std::vector<LinearStateSnapshot> linear_state_snapshots_;
     int precompute_len = 0;

--- a/src/runner/LLM_decode.cpp
+++ b/src/runner/LLM_decode.cpp
@@ -260,6 +260,8 @@ std::string LLM::Impl::Run(std::vector<unsigned short> &test_embed, int output_m
     // Reset per-run performance metrics; assigned once measured below.
     last_run_ttft_ms_ = -1.0f;
     last_run_decode_tps_ = -1.0f;
+    last_run_prefill_tps_ = -1.0f;
+    last_run_prefill_tokens_ = -1;
 
     std::vector<int> prefill_grp_list;
     const int default_prefill_gid = prefill_grpids_.empty() ? 1 : prefill_grpids_.front();
@@ -666,6 +668,13 @@ std::string LLM::Impl::Run(std::vector<unsigned short> &test_embed, int output_m
         // Store the same value reported by the "ttft:" log line above so the
         // OpenAI usage object matches on-device measurements.
         last_run_ttft_ms_ = (ttft_e2e_ms >= 0.0f) ? ttft_e2e_ms : ttft_text_ms;
+        // Prefill throughput: prompt tokens processed this run over the time to
+        // produce the first token (ttft_text_ms ~= prefill compute time, since the
+        // first token comes straight out of the last prefill forward pass).
+        if (ttft_text_ms > 0.0f && input_embed_num > 0)
+            last_run_prefill_tps_ = (float)input_embed_num / (ttft_text_ms / 1000.0f);
+        // Tokens actually prefilled this turn (prompt minus KV-cache-reused prefix).
+        last_run_prefill_tokens_ = input_embed_num;
         if (debug_prefill) ALOGI("first decode token: id=%d", next_token);
         if (next_token < 0 || next_token >= _attr.tokens_embed_num)
         {


### PR DESCRIPTION
…usage

Plumb prefill throughput (input_embed_num / prefill time) and the tokens actually prefilled this turn (prompt minus KV-cache-reused prefix) out of LLM_decode.cpp via new LLM getters (GetLastPrefillTps / GetLastPrefillTokens), and populate them on the streaming and non-streaming final usage chunks. Lets the lite_webui frontend show prefill speed and a "new N" count that reconciles prefill_tps with the tokens actually computed.

Bumps third_party/openai-api.cpp to the matching prefill commit.